### PR TITLE
Markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # git-hooks
 git-hooks - A tool for managing and invoking custom git hook scripts.
 
-## Description:
+##  Description:
 git-hooks is a tool to facilitate git hook management, specifically being
 able to store your hooks under source control within the repository itself
 and simply reference them from a multiplexer hook installed in the
@@ -16,7 +16,7 @@ configure it to do so.
 This way you can break your monolithic hooks into individual files, giving
 you greater flexibility regarding which pieces to run and when.
 
-## Installation:
+##  Installation:
 
 Install GNU getopt (if not already present for your platform).
 ```
@@ -55,7 +55,7 @@ functionality.
     git hooks install-template
 ```
 
-## Usage:
+##  Usage:
         git hooks  # equivalent to list
     or: git hooks list     [<git hook>...]
     or: git hooks enable     [-q|--quiet] <git hook>... <custom script name>...
@@ -74,7 +74,7 @@ functionality.
     or: git hooks config 
     or: git hooks help     [--markdown]
 
-## Files:
+##  Files:
     .githooks/
         This is where git-hooks will look for default hook scripts. Place your
         hook scripts in here rather than .git/hooks. Your hook scripts should
@@ -102,7 +102,7 @@ functionality.
         These files will be updated if you choose to install the hooks into your
         repository template by running 'git hooks install-template'.
 
-## Common Arguments:
+##  Common Arguments:
     <path>...
         The command accepts a list of path strings.
 
@@ -134,7 +134,7 @@ functionality.
         indicate scripts in the repo's .githooks directory. Standard git hook
         names are not considered valid items in this list.
 
-## Operations:
+##  Operations:
 
     list     [<git hook>...]
         Lists the currently available custom scripts for each standard git
@@ -250,31 +250,35 @@ functionality.
             If --markdown is specified, the help message will be generated with
             additional markdown syntax for headings and code blocks.
 
-## Writing custom git hook scripts:
+##  Writing custom git hook scripts:
 
-    Once git-hooks install has been called for your repository, creating and
-    installing your own hooks is a simple matter of placing them in the newly-
-    created .githooks directory. Your hooks must follow a particular naming
-    convention:
+Once "git-hooks install" has been called for your repository, creating and
+installing your own hooks is a simple matter of placing them in the newly-
+created .githooks directory. Your hooks must follow a particular naming
+convention:
 
-        <standard git hook name>-<custom suffix>
+```
+       <standard git hook name>-<custom suffix>
+```
 
-    When a git hook is invoked it will look for your hooks scripts with the
-    corresponding prefix and call them according to your config. By default
-    your scripts will be run sequentially in alphabetical order as they appear
-    in the .githooks directory.
+When a git hook is invoked it will look for your hooks scripts with the
+corresponding prefix and call them according to your config. By default
+your scripts will be run sequentially in alphabetical order as they appear
+in the .githooks directory.
 
-    Setting the parallel option (see above) will cause all scripts to be run
-    concurrently without regard to their conventional order.
+Setting the parallel option (see above) will cause all scripts to be run
+concurrently without regard to their conventional order.
 
-    Preventing parallel execution:
+##    Preventing parallel execution:
 
-        If your script cannot be run in parallel with another of the same
-        git hook family, you may enforce this by calling the exported function
-        prevent-parallel from within your script.
+If your script cannot be run in parallel with another of the same
+git hook family, you may enforce this by calling the exported function
+"prevent-parallel" from within your script.
 
-        Example:
+Example:
 
+```
         #!/usr/bin/env bash
         prevent-parallel   # Will exit the hook with a non-zero exit code
                            # unless it is being run sequentially.
+```

--- a/README.md
+++ b/README.md
@@ -2,50 +2,58 @@
 git-hooks - A tool for managing and invoking custom git hook scripts.
 
 ## Description:
-    git-hooks is a tool to facilitate git hook management, specifically being
-    able to store your hooks under source control within the repository itself
-    and simply reference them from a multiplexer hook installed in the
-    .git/hooks directory.
+git-hooks is a tool to facilitate git hook management, specifically being
+able to store your hooks under source control within the repository itself
+and simply reference them from a multiplexer hook installed in the
+`.git/hooks` directory.
 
-    The expected usage is to write an arbitrary number of individual hook
-    scripts associated with a single standard git hook and store them in the
-    .githooks directory. When git invokes the multiplexer script in .git/hooks,
-    it will call your custom scripts sequentially, or in parallel if you
-    configure it to do so.
+The expected usage is to write an arbitrary number of individual hook
+scripts associated with a single standard git hook and store them in the
+`.githooks` directory. When git invokes the multiplexer script in `.git/hooks`,
+it will call your custom scripts sequentially, or in parallel if you
+configure it to do so.
 
-    This way you can break your monolithic hooks into individual files, giving
-    you greater flexibility regarding which pieces to run and when.
+This way you can break your monolithic hooks into individual files, giving
+you greater flexibility regarding which pieces to run and when.
 
 ## Installation:
 
-    # Install GNU getopt (if not already present for your platform).
+Install GNU getopt (if not already present for your platform).
+```
     getopt -T
-    if [[ $? -ne 4 ]]; then
+    if [[ \$? -ne 4 ]]; then
         brew install gnu-getopt
         # -- or --
         sudo port install getopt
     fi
+```
 
-    # (Optional) Install 'git hooks' as a global alias.
-    # This allows you to do 'git hooks install' in new repositories rather than
-    # locating the command via its path.
-    # Regardless, a local alias will be created in your repository's git config
-    # in the next step.
+(Optional) Install 'git hooks' as a global alias.
+This allows you to do 'git hooks install' in new repositories rather than
+locating the command via its path.
+Regardless, a local alias will be created in your repository's git config
+in the next step.
+```
     path/to/git-hooks/git-hooks install-command --global
+```
 
-    # Install the multiplexers and the 'git hooks' alias in a repository.
+Install the multiplexers and the 'git hooks' alias in a repository.
+```
     cd <to your repo>
     git hooks install
     # -- or ---
     path/to/git-hooks/git-hooks install  # If you skipped the global alias step
+```
 
-    # Configure git to automatically install the multiplexers for all new
-    # repos (cloned or init'ed). This will make it so that you never have to
-    # run 'git hooks install' again for this machine.
-    # Useful when your repositories already have a .githooks directory with hook
-    # scripts in it or if you plan to make regular use of the 'git hooks'
-    # functionality.
+Configure git to automatically install the multiplexers for all new
+repos (cloned or init'ed). This will make it so that you never have to
+run 'git hooks install' again for this machine.
+Useful when your repositories already have a .githooks directory with hook
+scripts in it or if you plan to make regular use of the 'git hooks'
+functionality.
+```
     git hooks install-template
+```
 
 ## Usage:
         git hooks  # equivalent to list

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ you greater flexibility regarding which pieces to run and when.
 
 ## Installation:
 
-Install GNU getopt (if not already present for your platform).
+#### Install GNU getopt (if not already present for your platform).
 ```
 
     getopt -T
@@ -31,33 +31,37 @@ Install GNU getopt (if not already present for your platform).
 
 ```
 
-(Optional) Install 'git hooks' as a global alias.
-This allows you to do 'git hooks install' in new repositories rather than
-locating the command via its path.
-Regardless, a local alias will be created in your repository's git config
-in the next step.
+#### Install `git hooks` as a git global alias (optional)
+
+This allows you to do `git hooks install` in new repositories rather than
+locating the command via its path. Regardless, a local alias will be created
+in your repository's git config in the next step.
 ```
     path/to/git-hooks/git-hooks install-command --global
 ```
 
-Install the multiplexers and the 'git hooks' alias in a repository.
+#### Install the multiplexers and the 'git hooks' alias in a repository
 ```
 
     cd <to your repo>
     git hooks install
-    # -- or ---
-    path/to/git-hooks/git-hooks install  # If you skipped the global alias step
+    # -- or, if you skipped the global git alias step above ---
+    path/to/git-hooks/git-hooks install
 
 ```
 
-Configure git to automatically install the multiplexers for all new
-repos (cloned or init'ed). This will make it so that you never have to
-run 'git hooks install' again for this machine.
-Useful when your repositories already have a .githooks directory with hook
-scripts in it or if you plan to make regular use of the 'git hooks'
-functionality.
+#### Configure git to automatically install the multiplexers for all new repos (cloned or init'ed)
+
+This will make it so that you never have to run `git hooks install` again for this machine.
+This is useful when your repositories already have a `.githooks` directory with hook
+scripts in it or if you plan to make regular use of the `git hooks` functionality in other
+or future repositonies.
 ```
+
     git hooks install-template
+    # -- or, if you skipped the global git alias step above ---
+    path/to/git-hooks/git-hooks install-template
+
 ```
 
 ## Usage:
@@ -257,9 +261,9 @@ functionality.
 
 ## Writing custom git hook scripts:
 
-Once "git-hooks install" has been called for your repository, creating and
+Once `git-hooks install` has been called for your repository, creating and
 installing your own hooks is a simple matter of placing them in the newly-
-created .githooks directory. Your hooks must follow a particular naming
+created `.githooks` directory. Your hooks must follow a particular naming
 convention:
 
 ```
@@ -269,7 +273,7 @@ convention:
 When a git hook is invoked it will look for your hooks scripts with the
 corresponding prefix and call them according to your config. By default
 your scripts will be run sequentially in alphabetical order as they appear
-in the .githooks directory.
+in the `.githooks` directory.
 
 Setting the parallel option (see above) will cause all scripts to be run
 concurrently without regard to their conventional order.
@@ -278,7 +282,7 @@ concurrently without regard to their conventional order.
 
 If your script cannot be run in parallel with another of the same
 git hook family, you may enforce this by calling the exported function
-"prevent-parallel" from within your script.
+`prevent-parallel` from within your script.
 
 Example:
 ```

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
+# git-hooks
 git-hooks - A tool for managing and invoking custom git hook scripts.
 
-Description:
+##Description:
     git-hooks is a tool to facilitate git hook management, specifically being
     able to store your hooks under source control within the repository itself
     and simply reference them from a multiplexer hook installed in the
@@ -15,7 +16,7 @@ Description:
     This way you can break your monolithic hooks into individual files, giving
     you greater flexibility regarding which pieces to run and when.
 
-Installation:
+##Installation:
 
     # Install GNU getopt (if not already present for your platform).
     getopt -T
@@ -46,26 +47,26 @@ Installation:
     # functionality.
     git hooks install-template
 
-Usage:
+##Usage:
         git hooks  # equivalent to list
-    or: git hooks list [<git hook>...]
-    or: git hooks enable [-q|--quiet] <git hook>... <custom script name>...
-    or: git hooks disable [-q|--quiet] <git hook>... <custom script name>...
-    or: git hooks run [-f|--force] <git hook>|<custom script name>
-    or: git hooks install [-e|--examples] [--no-preserve]
+    or: git hooks list     [<git hook>...]
+    or: git hooks enable     [-q|--quiet] <git hook>... <custom script name>...
+    or: git hooks disable     [-q|--quiet] <git hook>... <custom script name>...
+    or: git hooks run     [-f|--force] <git hook>|<custom script name>
+    or: git hooks install     [-e|--examples] [--no-preserve]
     or: git hooks uninstall 
-    or: git hooks install-command [--global] [--core]
-    or: git hooks uninstall-command [--global] [--core]
+    or: git hooks install-command     [--global] [--core]
+    or: git hooks uninstall-command     [--global] [--core]
     or: git hooks install-template 
     or: git hooks uninstall-template 
-    or: git hooks include [<custom script name>...]
+    or: git hooks include     [<custom script name>...]
     or: git hooks check-support 
-    or: git hooks parallel <git hook> [<num>]
-    or: git hooks show-input <git hook> [true|false]
+    or: git hooks parallel     <git hook> [<num>]
+    or: git hooks show-input     <git hook> [true|false]
     or: git hooks config 
-    or: git hooks help 
+    or: git hooks help     [--markdown]
 
-Files:
+##Files:
     .githooks/
         This is where git-hooks will look for default hook scripts. Place your
         hook scripts in here rather than .git/hooks. Your hook scripts should
@@ -93,7 +94,7 @@ Files:
         These files will be updated if you choose to install the hooks into your
         repository template by running 'git hooks install-template'.
 
-Common Arguments:
+##Common Arguments:
     <path>...
         The command accepts a list of path strings.
 
@@ -125,26 +126,26 @@ Common Arguments:
         indicate scripts in the repo's .githooks directory. Standard git hook
         names are not considered valid items in this list.
 
-Operations:
+##Operations:
 
-    list [<git hook>...]
+    list     [<git hook>...]
         Lists the currently available custom scripts for each standard git
         hook. If any are disabled, it is noted in the output.
 
-    enable [-q|--quiet] <git hook>... <custom script name>...
+    enable     [-q|--quiet] <git hook>... <custom script name>...
         Enables a script (or scripts) to be run during git hook
         invocation. Scripts are enabled by default.
     
         If --quiet is specified, the updated enabled state of all hook
         scripts will not be displayed.
 
-    disable [-q|--quiet] <git hook>... <custom script name>...
+    disable     [-q|--quiet] <git hook>... <custom script name>...
         Prevents a script from being run during git hook invocation.
     
         If --quiet is specified, the updated enabled state of all hook
         scripts will not be displayed.
 
-    run [-f|--force] <git hook>|<custom script name>
+    run     [-f|--force] <git hook>|<custom script name>
         Runs a git hook or an individual custom script. stdin and any
         extra arguments will be forwarded to the designated target.
     
@@ -152,7 +153,7 @@ Operations:
         scripts. You can force the hook or script to run by specifying the
         --force flag.
 
-    install [-e|--examples] [--no-preserve]
+    install     [-e|--examples] [--no-preserve]
         Installs the multiplexer hooks into the .git/hooks directory.
         These scripts are the core of the git-hooks functionality.
         They are responsible for running any configured custom scripts
@@ -172,7 +173,7 @@ Operations:
         Removes the multiplexer hooks from the .git/hooks directory and
         removes the 'hooks' alias from the repo's config, if present.
 
-    install-command [--global] [--core]
+    install-command     [--global] [--core]
         Installs 'git-hooks' command into any of three locations.
             --global: Add it to the global git aliases
             --core: Links this file into this machine's git core
@@ -182,7 +183,7 @@ Operations:
         If neither --global nor --core are specified, the alias will be
         installed into the repo's local git config.
 
-    uninstall-command [--global] [--core]
+    uninstall-command     [--global] [--core]
         Clears the 'git-hooks' command from the specified location.
             --global: Remove it from the global aliases
             --core: Delete the git-hooks link from this machine's git
@@ -202,7 +203,7 @@ Operations:
     uninstall-template 
         Undoes the effects of 'install-template'.
 
-    include [<custom script name>...]
+    include     [<custom script name>...]
         Copies a script included with the git-hooks command to your
         repository's .githooks directory.
     
@@ -214,7 +215,7 @@ Operations:
         git-hooks and the list of hooks supported by git. If differences
         are present, consider upgrading git-hooks or git.
 
-    parallel <git hook> [<num>]
+    parallel     <git hook> [<num>]
         Modify the hooks.<git hook>.parallel config setting. <num> should
         be the desired number of jobs to spawn when running the hook
         scripts. If the second argument is not provided, it will display
@@ -226,7 +227,7 @@ Operations:
         When running in parallel, each script's output is buffered until
         it finishes. When complete, the output will be written to stdout.
 
-    show-input <git hook> [true|false]
+    show-input     <git hook> [true|false]
         Modify the hooks.<git hook>.showinput config setting. If no value
         is provided, it will display the current setting. If this setting
         is true, the received arguments and stdin will be displayed during
@@ -235,10 +236,13 @@ Operations:
     config 
         Simply lists all hooks-related git config settings.
 
-    help 
+    help     [--markdown]
         Displays this help message.
+    
+            If --markdown is specified, the help message will be generated with
+            additional markdown syntax for headings and code blocks.
 
-Writing custom git hook scripts:
+##Writing custom git hook scripts:
 
     Once git-hooks install has been called for your repository, creating and
     installing your own hooks is a simple matter of placing them in the newly-

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # git-hooks
 git-hooks - A tool for managing and invoking custom git hook scripts.
 
-##Description:
+## Description:
     git-hooks is a tool to facilitate git hook management, specifically being
     able to store your hooks under source control within the repository itself
     and simply reference them from a multiplexer hook installed in the
@@ -16,7 +16,7 @@ git-hooks - A tool for managing and invoking custom git hook scripts.
     This way you can break your monolithic hooks into individual files, giving
     you greater flexibility regarding which pieces to run and when.
 
-##Installation:
+## Installation:
 
     # Install GNU getopt (if not already present for your platform).
     getopt -T
@@ -47,7 +47,7 @@ git-hooks - A tool for managing and invoking custom git hook scripts.
     # functionality.
     git hooks install-template
 
-##Usage:
+## Usage:
         git hooks  # equivalent to list
     or: git hooks list     [<git hook>...]
     or: git hooks enable     [-q|--quiet] <git hook>... <custom script name>...
@@ -66,7 +66,7 @@ git-hooks - A tool for managing and invoking custom git hook scripts.
     or: git hooks config 
     or: git hooks help     [--markdown]
 
-##Files:
+## Files:
     .githooks/
         This is where git-hooks will look for default hook scripts. Place your
         hook scripts in here rather than .git/hooks. Your hook scripts should
@@ -94,7 +94,7 @@ git-hooks - A tool for managing and invoking custom git hook scripts.
         These files will be updated if you choose to install the hooks into your
         repository template by running 'git hooks install-template'.
 
-##Common Arguments:
+## Common Arguments:
     <path>...
         The command accepts a list of path strings.
 
@@ -126,7 +126,7 @@ git-hooks - A tool for managing and invoking custom git hook scripts.
         indicate scripts in the repo's .githooks directory. Standard git hook
         names are not considered valid items in this list.
 
-##Operations:
+## Operations:
 
     list     [<git hook>...]
         Lists the currently available custom scripts for each standard git
@@ -242,7 +242,7 @@ git-hooks - A tool for managing and invoking custom git hook scripts.
             If --markdown is specified, the help message will be generated with
             additional markdown syntax for headings and code blocks.
 
-##Writing custom git hook scripts:
+## Writing custom git hook scripts:
 
     Once git-hooks install has been called for your repository, creating and
     installing your own hooks is a simple matter of placing them in the newly-

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # git-hooks
-git-hooks - A tool for managing and invoking custom git hook scripts.
+A tool for managing and invoking custom git hook scripts.
 
-##  Description:
+## Description:
+
 git-hooks is a tool to facilitate git hook management, specifically being
 able to store your hooks under source control within the repository itself
 and simply reference them from a multiplexer hook installed in the
@@ -16,16 +17,18 @@ configure it to do so.
 This way you can break your monolithic hooks into individual files, giving
 you greater flexibility regarding which pieces to run and when.
 
-##  Installation:
+## Installation:
 
 Install GNU getopt (if not already present for your platform).
 ```
+
     getopt -T
-    if [[ \$? -ne 4 ]]; then
+    if [[ $? -ne 4 ]]; then
         brew install gnu-getopt
         # -- or --
         sudo port install getopt
     fi
+
 ```
 
 (Optional) Install 'git hooks' as a global alias.
@@ -39,10 +42,12 @@ in the next step.
 
 Install the multiplexers and the 'git hooks' alias in a repository.
 ```
+
     cd <to your repo>
     git hooks install
     # -- or ---
     path/to/git-hooks/git-hooks install  # If you skipped the global alias step
+
 ```
 
 Configure git to automatically install the multiplexers for all new
@@ -55,26 +60,26 @@ functionality.
     git hooks install-template
 ```
 
-##  Usage:
+## Usage:
         git hooks  # equivalent to list
-    or: git hooks list     [<git hook>...]
-    or: git hooks enable     [-q|--quiet] <git hook>... <custom script name>...
-    or: git hooks disable     [-q|--quiet] <git hook>... <custom script name>...
-    or: git hooks run     [-f|--force] <git hook>|<custom script name>
-    or: git hooks install     [-e|--examples] [--no-preserve]
+    or: git hooks list [<git hook>...]
+    or: git hooks enable [-q|--quiet] <git hook>... <custom script name>...
+    or: git hooks disable [-q|--quiet] <git hook>... <custom script name>...
+    or: git hooks run [-f|--force] <git hook>|<custom script name>
+    or: git hooks install [-e|--examples] [--no-preserve]
     or: git hooks uninstall 
-    or: git hooks install-command     [--global] [--core]
-    or: git hooks uninstall-command     [--global] [--core]
+    or: git hooks install-command [--global] [--core]
+    or: git hooks uninstall-command [--global] [--core]
     or: git hooks install-template 
     or: git hooks uninstall-template 
-    or: git hooks include     [<custom script name>...]
+    or: git hooks include [<custom script name>...]
     or: git hooks check-support 
-    or: git hooks parallel     <git hook> [<num>]
-    or: git hooks show-input     <git hook> [true|false]
+    or: git hooks parallel <git hook> [<num>]
+    or: git hooks show-input <git hook> [true|false]
     or: git hooks config 
-    or: git hooks help     [--markdown]
+    or: git hooks help [--markdown]
 
-##  Files:
+## Files:
     .githooks/
         This is where git-hooks will look for default hook scripts. Place your
         hook scripts in here rather than .git/hooks. Your hook scripts should
@@ -102,7 +107,7 @@ functionality.
         These files will be updated if you choose to install the hooks into your
         repository template by running 'git hooks install-template'.
 
-##  Common Arguments:
+## Common Arguments:
     <path>...
         The command accepts a list of path strings.
 
@@ -134,26 +139,26 @@ functionality.
         indicate scripts in the repo's .githooks directory. Standard git hook
         names are not considered valid items in this list.
 
-##  Operations:
+## Operations:
 
-    list     [<git hook>...]
+    list [<git hook>...]
         Lists the currently available custom scripts for each standard git
         hook. If any are disabled, it is noted in the output.
 
-    enable     [-q|--quiet] <git hook>... <custom script name>...
+    enable [-q|--quiet] <git hook>... <custom script name>...
         Enables a script (or scripts) to be run during git hook
         invocation. Scripts are enabled by default.
     
         If --quiet is specified, the updated enabled state of all hook
         scripts will not be displayed.
 
-    disable     [-q|--quiet] <git hook>... <custom script name>...
+    disable [-q|--quiet] <git hook>... <custom script name>...
         Prevents a script from being run during git hook invocation.
     
         If --quiet is specified, the updated enabled state of all hook
         scripts will not be displayed.
 
-    run     [-f|--force] <git hook>|<custom script name>
+    run [-f|--force] <git hook>|<custom script name>
         Runs a git hook or an individual custom script. stdin and any
         extra arguments will be forwarded to the designated target.
     
@@ -161,7 +166,7 @@ functionality.
         scripts. You can force the hook or script to run by specifying the
         --force flag.
 
-    install     [-e|--examples] [--no-preserve]
+    install [-e|--examples] [--no-preserve]
         Installs the multiplexer hooks into the .git/hooks directory.
         These scripts are the core of the git-hooks functionality.
         They are responsible for running any configured custom scripts
@@ -181,7 +186,7 @@ functionality.
         Removes the multiplexer hooks from the .git/hooks directory and
         removes the 'hooks' alias from the repo's config, if present.
 
-    install-command     [--global] [--core]
+    install-command [--global] [--core]
         Installs 'git-hooks' command into any of three locations.
             --global: Add it to the global git aliases
             --core: Links this file into this machine's git core
@@ -191,7 +196,7 @@ functionality.
         If neither --global nor --core are specified, the alias will be
         installed into the repo's local git config.
 
-    uninstall-command     [--global] [--core]
+    uninstall-command [--global] [--core]
         Clears the 'git-hooks' command from the specified location.
             --global: Remove it from the global aliases
             --core: Delete the git-hooks link from this machine's git
@@ -211,7 +216,7 @@ functionality.
     uninstall-template 
         Undoes the effects of 'install-template'.
 
-    include     [<custom script name>...]
+    include [<custom script name>...]
         Copies a script included with the git-hooks command to your
         repository's .githooks directory.
     
@@ -223,7 +228,7 @@ functionality.
         git-hooks and the list of hooks supported by git. If differences
         are present, consider upgrading git-hooks or git.
 
-    parallel     <git hook> [<num>]
+    parallel <git hook> [<num>]
         Modify the hooks.<git hook>.parallel config setting. <num> should
         be the desired number of jobs to spawn when running the hook
         scripts. If the second argument is not provided, it will display
@@ -235,7 +240,7 @@ functionality.
         When running in parallel, each script's output is buffered until
         it finishes. When complete, the output will be written to stdout.
 
-    show-input     <git hook> [true|false]
+    show-input <git hook> [true|false]
         Modify the hooks.<git hook>.showinput config setting. If no value
         is provided, it will display the current setting. If this setting
         is true, the received arguments and stdin will be displayed during
@@ -244,13 +249,13 @@ functionality.
     config 
         Simply lists all hooks-related git config settings.
 
-    help     [--markdown]
+    help [--markdown]
         Displays this help message.
     
-            If --markdown is specified, the help message will be generated with
-            additional markdown syntax for headings and code blocks.
+        If --markdown is specified, the help message will be generated with
+        additional markdown syntax for headings and code blocks.
 
-##  Writing custom git hook scripts:
+## Writing custom git hook scripts:
 
 Once "git-hooks install" has been called for your repository, creating and
 installing your own hooks is a simple matter of placing them in the newly-
@@ -269,16 +274,17 @@ in the .githooks directory.
 Setting the parallel option (see above) will cause all scripts to be run
 concurrently without regard to their conventional order.
 
-##    Preventing parallel execution:
+###    Preventing parallel execution:
 
 If your script cannot be run in parallel with another of the same
 git hook family, you may enforce this by calling the exported function
 "prevent-parallel" from within your script.
 
 Example:
-
 ```
+
         #!/usr/bin/env bash
         prevent-parallel   # Will exit the hook with a non-zero exit code
                            # unless it is being run sequentially.
+
 ```

--- a/git-hooks
+++ b/git-hooks
@@ -75,7 +75,7 @@ read -r -d '' HELP <<'HELP' || :
 $(md '# git-hooks')
 git-hooks - A tool for managing and invoking custom git hook scripts.
 
-$(md '##')Description:
+$(md '## ')Description:
     git-hooks is a tool to facilitate git hook management, specifically being
     able to store your hooks under source control within the repository itself
     and simply reference them from a multiplexer hook installed in the
@@ -90,7 +90,7 @@ $(md '##')Description:
     This way you can break your monolithic hooks into individual files, giving
     you greater flexibility regarding which pieces to run and when.
 
-$(md '##')Installation:
+$(md '## ')Installation:
 
     # Install GNU getopt (if not already present for your platform).
     getopt -T
@@ -121,7 +121,7 @@ $(md '##')Installation:
     # functionality.
     git hooks install-template
 
-$(md '##')Usage:
+$(md '## ')Usage:
         git hooks  # equivalent to list
     or: git hooks $(git_hooks__extract_desc list)
     or: git hooks $(git_hooks__extract_desc enable)
@@ -140,7 +140,7 @@ $(md '##')Usage:
     or: git hooks $(git_hooks__extract_desc config)
     or: git hooks $(git_hooks__extract_desc help)
 
-$(md '##')Files:
+$(md '## ')Files:
     .githooks/
         This is where git-hooks will look for default hook scripts. Place your
         hook scripts in here rather than .git/hooks. Your hook scripts should
@@ -168,7 +168,7 @@ $(md '##')Files:
         These files will be updated if you choose to install the hooks into your
         repository template by running 'git hooks install-template'.
 
-$(md '##')Common Arguments:
+$(md '## ')Common Arguments:
     <path>...
         The command accepts a list of path strings.
 
@@ -183,10 +183,10 @@ $(echo ${GITHOOKS[*]} | xargs -L1 -n1 | sed 's/^/            /g')
         indicate scripts in the repo's .githooks directory. Standard git hook
         names are not considered valid items in this list.
 
-$(md '##')Operations:
+$(md '## ')Operations:
 $(git_hooks__extract_help)
 
-$(md '##')Writing custom git hook scripts:
+$(md '## ')Writing custom git hook scripts:
 
     Once "git-hooks install" has been called for your repository, creating and
     installing your own hooks is a simple matter of placing them in the newly-

--- a/git-hooks
+++ b/git-hooks
@@ -70,13 +70,6 @@ function md_block_monospace {
     fi
 }
 
-function md_no_indent {
-  if $USE_MARKDOWN; then
-    sed 's/^[ \t]*//' <<< "$@"
-  else echo "$@"
-  fi
-}
-
 function md_no_indent_or_hash {
   if $USE_MARKDOWN; then
     sed 's/^[ \t]*[#]*[ \t]*//' <<< "$@"
@@ -91,7 +84,7 @@ read -r -d '' HELP <<'HELP' || :
 $(md '# git-hooks')
 git-hooks - A tool for managing and invoking custom git hook scripts.
 
-$(md '## ')Description:
+$(md '## ') Description:
 $(md_no_indent_or_hash "    git-hooks is a tool to facilitate git hook management, specifically being
     able to store your hooks under source control within the repository itself
     and simply reference them from a multiplexer hook installed in the
@@ -106,7 +99,7 @@ $(md_no_indent_or_hash "    git-hooks is a tool to facilitate git hook managemen
     This way you can break your monolithic hooks into individual files, giving
     you greater flexibility regarding which pieces to run and when.")
 
-$(md '## ')Installation:
+$(md '## ') Installation:
 
 $(md_no_indent_or_hash "    # Install GNU getopt (if not already present for your platform).")
 $(md_block_monospace '    getopt -T
@@ -137,7 +130,7 @@ $(md_no_indent_or_hash "    # Configure git to automatically install the multipl
     # functionality.")
 $(md_block_monospace '    git hooks install-template')
 
-$(md '## ')Usage:
+$(md '## ') Usage:
         git hooks  # equivalent to list
     or: git hooks $(git_hooks__extract_desc list)
     or: git hooks $(git_hooks__extract_desc enable)
@@ -156,7 +149,7 @@ $(md '## ')Usage:
     or: git hooks $(git_hooks__extract_desc config)
     or: git hooks $(git_hooks__extract_desc help)
 
-$(md '## ')Files:
+$(md '## ') Files:
     .githooks/
         This is where git-hooks will look for default hook scripts. Place your
         hook scripts in here rather than .git/hooks. Your hook scripts should
@@ -184,7 +177,7 @@ $(md '## ')Files:
         These files will be updated if you choose to install the hooks into your
         repository template by running 'git hooks install-template'.
 
-$(md '## ')Common Arguments:
+$(md '## ') Common Arguments:
     <path>...
         The command accepts a list of path strings.
 
@@ -199,37 +192,37 @@ $(echo ${GITHOOKS[*]} | xargs -L1 -n1 | sed 's/^/            /g')
         indicate scripts in the repo's .githooks directory. Standard git hook
         names are not considered valid items in this list.
 
-$(md '## ')Operations:
+$(md '## ') Operations:
 $(git_hooks__extract_help)
 
-$(md '## ')Writing custom git hook scripts:
+$(md '## ') Writing custom git hook scripts:
 
-    Once "git-hooks install" has been called for your repository, creating and
+$(md_no_indent_or_hash '    Once "git-hooks install" has been called for your repository, creating and
     installing your own hooks is a simple matter of placing them in the newly-
     created .githooks directory. Your hooks must follow a particular naming
-    convention:
+    convention:')
 
-        <standard git hook name>-<custom suffix>
+$(md_block_monospace '       <standard git hook name>-<custom suffix>')
 
-    When a git hook is invoked it will look for your hooks scripts with the
+$(md_no_indent_or_hash '    When a git hook is invoked it will look for your hooks scripts with the
     corresponding prefix and call them according to your config. By default
     your scripts will be run sequentially in alphabetical order as they appear
     in the .githooks directory.
 
     Setting the parallel option (see above) will cause all scripts to be run
-    concurrently without regard to their conventional order.
+    concurrently without regard to their conventional order.')
 
-    Preventing parallel execution:
+$(md '## ')   Preventing parallel execution:
 
-        If your script cannot be run in parallel with another of the same
+$(md_no_indent_or_hash '        If your script cannot be run in parallel with another of the same
         git hook family, you may enforce this by calling the exported function
         "prevent-parallel" from within your script.
 
-        Example:
+        Example:')
 
-        #!/usr/bin/env bash
+$(md_block_monospace '        #!/usr/bin/env bash
         prevent-parallel   # Will exit the hook with a non-zero exit code
-                           # unless it is being run sequentially.
+                           # unless it is being run sequentially.')
 
 HELP
 

--- a/git-hooks
+++ b/git-hooks
@@ -50,13 +50,32 @@ if ! command -v $getopt &>/dev/null; then
 fi
 set -e
 
+function md {
+    if $USE_MARKDOWN; then
+        echo -n "$@"
+    fi
+}
+
+function md_inline_monospace {
+    if $USE_MARKDOWN; then
+        echo -n "\`$@\`"
+    fi
+}
+
+function md_block_monospace {
+    if $USE_MARKDOWN; then
+        echo -n "\`\`\`$@\`\`\`"
+    fi
+}
+
 
 # HELP
 #############################################
 read -r -d '' HELP <<'HELP' || :
+$(md '# git-hooks')
 git-hooks - A tool for managing and invoking custom git hook scripts.
 
-Description:
+$(md '##')Description:
     git-hooks is a tool to facilitate git hook management, specifically being
     able to store your hooks under source control within the repository itself
     and simply reference them from a multiplexer hook installed in the
@@ -71,7 +90,7 @@ Description:
     This way you can break your monolithic hooks into individual files, giving
     you greater flexibility regarding which pieces to run and when.
 
-Installation:
+$(md '##')Installation:
 
     # Install GNU getopt (if not already present for your platform).
     getopt -T
@@ -102,7 +121,7 @@ Installation:
     # functionality.
     git hooks install-template
 
-Usage:
+$(md '##')Usage:
         git hooks  # equivalent to list
     or: git hooks $(git_hooks__extract_desc list)
     or: git hooks $(git_hooks__extract_desc enable)
@@ -121,7 +140,7 @@ Usage:
     or: git hooks $(git_hooks__extract_desc config)
     or: git hooks $(git_hooks__extract_desc help)
 
-Files:
+$(md '##')Files:
     .githooks/
         This is where git-hooks will look for default hook scripts. Place your
         hook scripts in here rather than .git/hooks. Your hook scripts should
@@ -149,7 +168,7 @@ Files:
         These files will be updated if you choose to install the hooks into your
         repository template by running 'git hooks install-template'.
 
-Common Arguments:
+$(md '##')Common Arguments:
     <path>...
         The command accepts a list of path strings.
 
@@ -164,10 +183,10 @@ $(echo ${GITHOOKS[*]} | xargs -L1 -n1 | sed 's/^/            /g')
         indicate scripts in the repo's .githooks directory. Standard git hook
         names are not considered valid items in this list.
 
-Operations:
+$(md '##')Operations:
 $(git_hooks__extract_help)
 
-Writing custom git hook scripts:
+$(md '##')Writing custom git hook scripts:
 
     Once "git-hooks install" has been called for your repository, creating and
     installing your own hooks is a simple matter of placing them in the newly-
@@ -277,13 +296,27 @@ function git_hooks__extract_doc {
 }
 
 
-
-
 function git_hooks_help {
+    : <<-ARGS
+	    [--markdown]
+	ARGS
     : <<-HELP
 	    Displays this help message.
+
+        If --markdown is specified, the help message will be generated with
+        additional markdown syntax for headings and code blocks.
 	HELP
 
+    eval set -- "$($getopt -o m --long markdown -- $@)"
+    export USE_MARKDOWN=false;
+    while [[ $1 != -- ]]; do
+        case $1 in
+            -m|--markdown)
+                export USE_MARKDOWN=true; shift;;
+            *) echo "Unrecognized option: $1"; return 1;;
+        esac
+    done
+    shift
     if [[ -n ${1:-} ]]; then
         printf "git hooks %s\n" $(git_hooks__extract_desc $1)
         echo
@@ -978,8 +1011,6 @@ else
     GITHOOKSDIR=
     HOOKSDIR=
 fi
-
-
 
 # Main functionality
 #############################################

--- a/git-hooks
+++ b/git-hooks
@@ -59,13 +59,22 @@ function md {
 function md_inline_monospace {
     if $USE_MARKDOWN; then
         echo -n "\`$@\`"
+      else echo "$@"
     fi
 }
 
 function md_block_monospace {
     if $USE_MARKDOWN; then
         echo -n "\`\`\`$@\`\`\`"
+      else echo "$@"
     fi
+}
+
+function md_no_indent {
+  if $USE_MARKDOWN; then
+    sed 's/^[ \t]*//' <<< "$@"
+  else echo "$@"
+  fi
 }
 
 
@@ -76,19 +85,19 @@ $(md '# git-hooks')
 git-hooks - A tool for managing and invoking custom git hook scripts.
 
 $(md '## ')Description:
-    git-hooks is a tool to facilitate git hook management, specifically being
+$(md_no_indent "    git-hooks is a tool to facilitate git hook management, specifically being
     able to store your hooks under source control within the repository itself
     and simply reference them from a multiplexer hook installed in the
-    .git/hooks directory.
+    $(md_inline_monospace .git/hooks) directory.
 
     The expected usage is to write an arbitrary number of individual hook
     scripts associated with a single standard git hook and store them in the
-    .githooks directory. When git invokes the multiplexer script in .git/hooks,
+    $(md_inline_monospace .githooks) directory. When git invokes the multiplexer script in $(md_inline_monospace .git/hooks),
     it will call your custom scripts sequentially, or in parallel if you
     configure it to do so.
 
     This way you can break your monolithic hooks into individual files, giving
-    you greater flexibility regarding which pieces to run and when.
+    you greater flexibility regarding which pieces to run and when.")
 
 $(md '## ')Installation:
 

--- a/git-hooks
+++ b/git-hooks
@@ -65,7 +65,7 @@ function md_inline_monospace {
 
 function md_block_monospace {
     if $USE_MARKDOWN; then
-        echo -n "\`\`\`$@\`\`\`"
+        echo -e "\`\`\`\n$@\n\`\`\`"
       else echo "$@"
     fi
 }
@@ -73,6 +73,13 @@ function md_block_monospace {
 function md_no_indent {
   if $USE_MARKDOWN; then
     sed 's/^[ \t]*//' <<< "$@"
+  else echo "$@"
+  fi
+}
+
+function md_no_indent_or_hash {
+  if $USE_MARKDOWN; then
+    sed 's/^[ \t]*[#]*[ \t]*//' <<< "$@"
   else echo "$@"
   fi
 }
@@ -85,7 +92,7 @@ $(md '# git-hooks')
 git-hooks - A tool for managing and invoking custom git hook scripts.
 
 $(md '## ')Description:
-$(md_no_indent "    git-hooks is a tool to facilitate git hook management, specifically being
+$(md_no_indent_or_hash "    git-hooks is a tool to facilitate git hook management, specifically being
     able to store your hooks under source control within the repository itself
     and simply reference them from a multiplexer hook installed in the
     $(md_inline_monospace .git/hooks) directory.
@@ -101,34 +108,34 @@ $(md_no_indent "    git-hooks is a tool to facilitate git hook management, speci
 
 $(md '## ')Installation:
 
-    # Install GNU getopt (if not already present for your platform).
-    getopt -T
+$(md_no_indent_or_hash "    # Install GNU getopt (if not already present for your platform).")
+$(md_block_monospace '    getopt -T
     if [[ \$? -ne 4 ]]; then
         brew install gnu-getopt
         # -- or --
         sudo port install getopt
-    fi
+    fi')
 
-    # (Optional) Install 'git hooks' as a global alias.
+$(md_no_indent_or_hash "    # (Optional) Install 'git hooks' as a global alias.
     # This allows you to do 'git hooks install' in new repositories rather than
     # locating the command via its path.
     # Regardless, a local alias will be created in your repository's git config
-    # in the next step.
-    path/to/git-hooks/git-hooks install-command --global
+    # in the next step.")
+$(md_block_monospace '    path/to/git-hooks/git-hooks install-command --global')
 
-    # Install the multiplexers and the 'git hooks' alias in a repository.
-    cd <to your repo>
+$(md_no_indent_or_hash "    # Install the multiplexers and the 'git hooks' alias in a repository.")
+$(md_block_monospace '    cd <to your repo>
     git hooks install
     # -- or ---
-    path/to/git-hooks/git-hooks install  # If you skipped the global alias step
+    path/to/git-hooks/git-hooks install  # If you skipped the global alias step')
 
-    # Configure git to automatically install the multiplexers for all new
+$(md_no_indent_or_hash "    # Configure git to automatically install the multiplexers for all new
     # repos (cloned or init'ed). This will make it so that you never have to
     # run 'git hooks install' again for this machine.
     # Useful when your repositories already have a .githooks directory with hook
     # scripts in it or if you plan to make regular use of the 'git hooks'
-    # functionality.
-    git hooks install-template
+    # functionality.")
+$(md_block_monospace '    git hooks install-template')
 
 $(md '## ')Usage:
         git hooks  # equivalent to list

--- a/git-hooks
+++ b/git-hooks
@@ -56,6 +56,12 @@ function md {
     fi
 }
 
+function md_omit {
+    if ! $USE_MARKDOWN; then
+        echo -n "$@"
+    fi
+}
+
 function md_inline_monospace {
     if $USE_MARKDOWN; then
         echo -n "\`$@\`"
@@ -82,10 +88,11 @@ function md_no_indent_or_hash {
 #############################################
 read -r -d '' HELP <<'HELP' || :
 $(md '# git-hooks')
-git-hooks - A tool for managing and invoking custom git hook scripts.
+$(md_omit "git-hooks - ")A tool for managing and invoking custom git hook scripts.
 
-$(md '## ') Description:
-$(md_no_indent_or_hash "    git-hooks is a tool to facilitate git hook management, specifically being
+$(md '##') Description:
+$(md_no_indent_or_hash "
+    git-hooks is a tool to facilitate git hook management, specifically being
     able to store your hooks under source control within the repository itself
     and simply reference them from a multiplexer hook installed in the
     $(md_inline_monospace .git/hooks) directory.
@@ -97,40 +104,48 @@ $(md_no_indent_or_hash "    git-hooks is a tool to facilitate git hook managemen
     configure it to do so.
 
     This way you can break your monolithic hooks into individual files, giving
-    you greater flexibility regarding which pieces to run and when.")
+    you greater flexibility regarding which pieces to run and when.
+")
 
-$(md '## ') Installation:
+$(md '##') Installation:
 
 $(md_no_indent_or_hash "    # Install GNU getopt (if not already present for your platform).")
-$(md_block_monospace '    getopt -T
-    if [[ \$? -ne 4 ]]; then
+$(md_block_monospace '
+    getopt -T
+    if [[ $? -ne 4 ]]; then
         brew install gnu-getopt
         # -- or --
         sudo port install getopt
-    fi')
-
-$(md_no_indent_or_hash "    # (Optional) Install 'git hooks' as a global alias.
+    fi
+')
+$(md_no_indent_or_hash "
+    # (Optional) Install 'git hooks' as a global alias.
     # This allows you to do 'git hooks install' in new repositories rather than
     # locating the command via its path.
     # Regardless, a local alias will be created in your repository's git config
-    # in the next step.")
+    # in the next step.
+")
 $(md_block_monospace '    path/to/git-hooks/git-hooks install-command --global')
-
-$(md_no_indent_or_hash "    # Install the multiplexers and the 'git hooks' alias in a repository.")
-$(md_block_monospace '    cd <to your repo>
+$(md_no_indent_or_hash "
+    # Install the multiplexers and the 'git hooks' alias in a repository.
+")
+$(md_block_monospace '
+    cd <to your repo>
     git hooks install
     # -- or ---
-    path/to/git-hooks/git-hooks install  # If you skipped the global alias step')
-
-$(md_no_indent_or_hash "    # Configure git to automatically install the multiplexers for all new
+    path/to/git-hooks/git-hooks install  # If you skipped the global alias step
+')
+$(md_no_indent_or_hash "
+    # Configure git to automatically install the multiplexers for all new
     # repos (cloned or init'ed). This will make it so that you never have to
     # run 'git hooks install' again for this machine.
     # Useful when your repositories already have a .githooks directory with hook
     # scripts in it or if you plan to make regular use of the 'git hooks'
-    # functionality.")
+    # functionality.
+")
 $(md_block_monospace '    git hooks install-template')
 
-$(md '## ') Usage:
+$(md '##') Usage:
         git hooks  # equivalent to list
     or: git hooks $(git_hooks__extract_desc list)
     or: git hooks $(git_hooks__extract_desc enable)
@@ -149,7 +164,7 @@ $(md '## ') Usage:
     or: git hooks $(git_hooks__extract_desc config)
     or: git hooks $(git_hooks__extract_desc help)
 
-$(md '## ') Files:
+$(md '##') Files:
     .githooks/
         This is where git-hooks will look for default hook scripts. Place your
         hook scripts in here rather than .git/hooks. Your hook scripts should
@@ -177,7 +192,7 @@ $(md '## ') Files:
         These files will be updated if you choose to install the hooks into your
         repository template by running 'git hooks install-template'.
 
-$(md '## ') Common Arguments:
+$(md '##') Common Arguments:
     <path>...
         The command accepts a list of path strings.
 
@@ -192,37 +207,41 @@ $(echo ${GITHOOKS[*]} | xargs -L1 -n1 | sed 's/^/            /g')
         indicate scripts in the repo's .githooks directory. Standard git hook
         names are not considered valid items in this list.
 
-$(md '## ') Operations:
+$(md '##') Operations:
 $(git_hooks__extract_help)
 
-$(md '## ') Writing custom git hook scripts:
-
-$(md_no_indent_or_hash '    Once "git-hooks install" has been called for your repository, creating and
+$(md '##') Writing custom git hook scripts:
+$(md_no_indent_or_hash '
+    Once "git-hooks install" has been called for your repository, creating and
     installing your own hooks is a simple matter of placing them in the newly-
     created .githooks directory. Your hooks must follow a particular naming
-    convention:')
+    convention:
+')
 
 $(md_block_monospace '       <standard git hook name>-<custom suffix>')
-
-$(md_no_indent_or_hash '    When a git hook is invoked it will look for your hooks scripts with the
+$(md_no_indent_or_hash '
+    When a git hook is invoked it will look for your hooks scripts with the
     corresponding prefix and call them according to your config. By default
     your scripts will be run sequentially in alphabetical order as they appear
     in the .githooks directory.
 
     Setting the parallel option (see above) will cause all scripts to be run
-    concurrently without regard to their conventional order.')
+    concurrently without regard to their conventional order.
+')
 
-$(md '## ')   Preventing parallel execution:
-
-$(md_no_indent_or_hash '        If your script cannot be run in parallel with another of the same
+$(md '###')    Preventing parallel execution:
+$(md_no_indent_or_hash '
+        If your script cannot be run in parallel with another of the same
         git hook family, you may enforce this by calling the exported function
         "prevent-parallel" from within your script.
 
-        Example:')
-
-$(md_block_monospace '        #!/usr/bin/env bash
+        Example:
+')
+$(md_block_monospace '
+        #!/usr/bin/env bash
         prevent-parallel   # Will exit the hook with a non-zero exit code
-                           # unless it is being run sequentially.')
+                           # unless it is being run sequentially.
+')
 
 HELP
 
@@ -312,8 +331,8 @@ function git_hooks_help {
     : <<-HELP
 	    Displays this help message.
 
-        If --markdown is specified, the help message will be generated with
-        additional markdown syntax for headings and code blocks.
+	    If --markdown is specified, the help message will be generated with
+	    additional markdown syntax for headings and code blocks.
 	HELP
 
     eval set -- "$($getopt -o m --long markdown -- $@)"

--- a/git-hooks
+++ b/git-hooks
@@ -62,25 +62,36 @@ function md_omit {
     fi
 }
 
+function md_inline_quotes {
+    if $USE_MARKDOWN; then
+        echo -n "\`$@\`"
+    else
+        echo -n "'$@'"
+    fi
+}
+
 function md_inline_monospace {
     if $USE_MARKDOWN; then
         echo -n "\`$@\`"
-      else echo "$@"
+    else
+        echo "$@"
     fi
 }
 
 function md_block_monospace {
     if $USE_MARKDOWN; then
         echo -e "\`\`\`\n$@\n\`\`\`"
-      else echo "$@"
+    else
+        echo "$@"
     fi
 }
 
 function md_no_indent_or_hash {
-  if $USE_MARKDOWN; then
-    sed 's/^[ \t]*[#]*[ \t]*//' <<< "$@"
-  else echo "$@"
-  fi
+    if $USE_MARKDOWN; then
+        sed 's/^[ \t]*[#]*[ \t]*//' <<< "$@"
+    else
+        echo "$@"
+    fi
 }
 
 
@@ -99,7 +110,7 @@ $(md_no_indent_or_hash "
 
     The expected usage is to write an arbitrary number of individual hook
     scripts associated with a single standard git hook and store them in the
-    $(md_inline_monospace .githooks) directory. When git invokes the multiplexer script in $(md_inline_monospace .git/hooks),
+    $(md_inline_monospace '.githooks') directory. When git invokes the multiplexer script in $(md_inline_monospace .git/hooks),
     it will call your custom scripts sequentially, or in parallel if you
     configure it to do so.
 
@@ -109,7 +120,7 @@ $(md_no_indent_or_hash "
 
 $(md '##') Installation:
 
-$(md_no_indent_or_hash "    # Install GNU getopt (if not already present for your platform).")
+$(md '#### ')$(md_no_indent_or_hash "    # Install GNU getopt (if not already present for your platform).")
 $(md_block_monospace '
     getopt -T
     if [[ $? -ne 4 ]]; then
@@ -118,32 +129,35 @@ $(md_block_monospace '
         sudo port install getopt
     fi
 ')
+
+$(md '#### ')$(md_no_indent_or_hash "    # Install $(md_inline_quotes 'git hooks') as a git global alias (optional)")
 $(md_no_indent_or_hash "
-    # (Optional) Install 'git hooks' as a global alias.
-    # This allows you to do 'git hooks install' in new repositories rather than
-    # locating the command via its path.
-    # Regardless, a local alias will be created in your repository's git config
-    # in the next step.
+    # This allows you to do $(md_inline_quotes 'git hooks install') in new repositories rather than
+    # locating the command via its path. Regardless, a local alias will be created
+    # in your repository's git config in the next step.
 ")
 $(md_block_monospace '    path/to/git-hooks/git-hooks install-command --global')
-$(md_no_indent_or_hash "
-    # Install the multiplexers and the 'git hooks' alias in a repository.
-")
+
+$(md '#### ')$(md_no_indent_or_hash "    # Install the multiplexers and the 'git hooks' alias in a repository")
 $(md_block_monospace '
     cd <to your repo>
     git hooks install
-    # -- or ---
-    path/to/git-hooks/git-hooks install  # If you skipped the global alias step
+    # -- or, if you skipped the global git alias step above ---
+    path/to/git-hooks/git-hooks install
 ')
+
+$(md '#### ')$(md_no_indent_or_hash "    # Configure git to automatically install the multiplexers for all new repos (cloned or init'ed)")
 $(md_no_indent_or_hash "
-    # Configure git to automatically install the multiplexers for all new
-    # repos (cloned or init'ed). This will make it so that you never have to
-    # run 'git hooks install' again for this machine.
-    # Useful when your repositories already have a .githooks directory with hook
-    # scripts in it or if you plan to make regular use of the 'git hooks'
-    # functionality.
+    # This will make it so that you never have to run $(md_inline_quotes 'git hooks install') again for this machine.
+    # This is useful when your repositories already have a $(md_inline_monospace '.githooks') directory with hook
+    # scripts in it or if you plan to make regular use of the $(md_inline_quotes 'git hooks') functionality in other
+    # or future repositonies.
 ")
-$(md_block_monospace '    git hooks install-template')
+$(md_block_monospace '
+    git hooks install-template
+    # -- or, if you skipped the global git alias step above ---
+    path/to/git-hooks/git-hooks install-template
+')
 
 $(md '##') Usage:
         git hooks  # equivalent to list
@@ -211,32 +225,32 @@ $(md '##') Operations:
 $(git_hooks__extract_help)
 
 $(md '##') Writing custom git hook scripts:
-$(md_no_indent_or_hash '
-    Once "git-hooks install" has been called for your repository, creating and
+$(md_no_indent_or_hash "
+    Once $(md_inline_quotes 'git-hooks install') has been called for your repository, creating and
     installing your own hooks is a simple matter of placing them in the newly-
-    created .githooks directory. Your hooks must follow a particular naming
+    created $(md_inline_monospace '.githooks') directory. Your hooks must follow a particular naming
     convention:
-')
+")
 
 $(md_block_monospace '       <standard git hook name>-<custom suffix>')
-$(md_no_indent_or_hash '
+$(md_no_indent_or_hash "
     When a git hook is invoked it will look for your hooks scripts with the
     corresponding prefix and call them according to your config. By default
     your scripts will be run sequentially in alphabetical order as they appear
-    in the .githooks directory.
+    in the $(md_inline_monospace '.githooks') directory.
 
     Setting the parallel option (see above) will cause all scripts to be run
     concurrently without regard to their conventional order.
-')
+")
 
 $(md '###')    Preventing parallel execution:
-$(md_no_indent_or_hash '
+$(md_no_indent_or_hash "
         If your script cannot be run in parallel with another of the same
         git hook family, you may enforce this by calling the exported function
-        "prevent-parallel" from within your script.
+        $(md_inline_quotes 'prevent-parallel') from within your script.
 
         Example:
-')
+")
 $(md_block_monospace '
         #!/usr/bin/env bash
         prevent-parallel   # Will exit the hook with a non-zero exit code


### PR DESCRIPTION
Update `git hooks help` to take `--markdown` flag that generates help document with markdown included. Update README.