### PR TITLE
[ENG-61] Add global git hooks support

### DIFF
--- a/.githooks/commit-msg/jira-format
+++ b/.githooks/commit-msg/jira-format
@@ -1,5 +1,0 @@
-#!/usr/bin/env git-hooks
-
-[git-hooks]
-	collection = git-hooks
-	hook = commit-msg/jira-format

--- a/.gitmessage
+++ b/.gitmessage
@@ -1,0 +1,8 @@
+[$JIRA]
+# Subject: Description in the imperative voice
+
+
+# Summary: A paragraph or two explaining the reason for the change and a
+#          high level explanation of what the changes do.
+
+[$JIRA](https://fivestars.atlassian.net/browse/$JIRA)

--- a/README.md
+++ b/README.md
@@ -72,8 +72,8 @@ or future repositonies.
     or: git hooks uninstall-command 
     or: git hooks install-template 
     or: git hooks uninstall-template 
-    or: git hooks add-collection <collection name> <clone url> [<subpath to hooks>]
-    or: git hooks include <collection name> <git hook> <hook executable> [<new name>]
+    or: git hooks add-collection [-g|--global] <collection name> <clone url> [<subpath to hooks>]
+    or: git hooks include [-g|--global] <collection name> <git hook> <hook executable> [<new name>]
     or: git hooks check-support 
     or: git hooks parallel <git hook> [<num>]
     or: git hooks show-input <git hook> [true|false]
@@ -216,10 +216,11 @@ or future repositonies.
     uninstall-template 
         Undoes the effects of 'install-template'.
 
-    add-collection <collection name> <clone url> [<subpath to hooks>]
+    add-collection [-g|--global] <collection name> <clone url> [<subpath to hooks>]
         Configures this repository to be able to reference git hooks hosted
         in a remote locatior (currently only supports git repositories).
     
+            [-g|--global]:      The collection will be considered available to all repos
         <collection name>:  The internal name for the collection. Must be unique
                             within this repository.
     
@@ -227,13 +228,19 @@ or future repositonies.
     
         <subpath to hooks>: The collection-relative path to the hook directories.
 
-    include <collection name> <git hook> <hook executable> [<new name>]
+    include [-g|--global] <collection name> <git hook> <hook executable> [<new name>]
         Link an existing script from a collection into this repository.
         If <new name> is provided, that name will be used instead of <hook script>
         for the reference file installed into the repository. This is useful when one
         wishes to specify a strict order to in which to run multiple scripts for
         <git hook>. Just provide a numeric prefix on the <new name> to indicate
         the script's place in the running order.
+    
+            Specify '--global' if you want to reference a hook in a global collection.
+            Using this, it's possible to take advantage of project-agnostic hooks without
+            even placing them (or references to them) under your project's source control.
+            Bear in mind that some hooks will place files under the project's source
+            control as a side-effect of their behavior. This is to be expected.
 
     check-support 
         Checks for differences in the list of hooks supported by

--- a/README.md
+++ b/README.md
@@ -17,6 +17,49 @@ configure it to do so.
 This way you can break your monolithic hooks into individual files, giving
 you greater flexibility regarding which pieces to run and when.
 
+## Features:
+
+### Run your hooks directly:
+
+git-hooks allows you to invoke your hook scripts without being triggered by
+a git action. This is useful for speeding up the process of debugging issues
+that caused your hooks to fail in the first place. If you write your hook
+scripts well, you can even pass extra arguments to your scripts that wouldn't
+be present when being run from a git trigger. (eg. specifying a particular
+unit test to speed up debugging).
+
+### Disable/enable particular hooks or hook scripts:
+
+git-hooks gives you the ability to disable hooks down to the individual script
+level. So if something is preventing a particular script from succeeding and
+can be temporarily ignored, you can just disable that one and the other scripts
+for that trigger will still apply. This is much better than `--no-verify`.
+
+### Hook repositories:
+
+Rather than copying and pasting the same hook code into each of your
+repositories, you can create a shared collection of hooks (as a git repo) and
+simply reference those from within your repository. This way, as your hook
+functionality evolves, you only need to push the code to the collection's
+repo, and git-hooks will ensure that you pull down the latest.
+
+### Global hooks:
+
+You can have global hooks on your machine. These will be run for any
+repository that has git-hooks installed (ie. has the multiplexer scripts
+in its `.git/hooks` dir. See **Installation** below). This
+is useful for applying consistent, project-agnostic rules across all of
+your projects (such as commit message format/structure). These hooks can
+be literal script files or reference hooks, but they will not be checked
+into the source control of the repositories that they will affect. They
+will appear and run alongside the repo's own hooks.
+
+Global hooks will be enabled by default for all repos with git-hooks
+installed. If you wish to prevent the global git hooks from running for
+a repostiory, set the local git config value of `git-hooks.global-enabled`
+to `false`. This will allow you to continue to use the repo's
+source-controlled git hooks.
+
 ## Installation:
 
 #### Install GNU getopt (if not already present for your platform).

--- a/README.md
+++ b/README.md
@@ -196,8 +196,7 @@ or future repositonies.
         "-moved" suffix.
 
     uninstall 
-        Removes the multiplexer hooks from the .git/hooks directory and
-        removes the 'git-hooks' symlink from /usr/local/bin, if present.
+        Removes the multiplexer hooks from the .git/hooks directory.
 
     install-command 
         Creates a symlink to 'git-hooks' in /usr/local/bin

--- a/git-hooks
+++ b/git-hooks
@@ -133,6 +133,14 @@ function md_inline_quotes {
     fi
 }
 
+function md_inline_bold {
+    if $USE_MARKDOWN; then
+        echo -n "**$***"
+    else
+        echo -n "$*"
+    fi
+}
+
 function md_inline_monospace {
     if $USE_MARKDOWN; then
         echo -n "\`$*\`"
@@ -179,6 +187,53 @@ $(md_no_indent_or_hash "
 
     This way you can break your monolithic hooks into individual files, giving
     you greater flexibility regarding which pieces to run and when.
+")
+
+$(md '##') Features:
+
+$(md '###') Run your hooks directly:
+$(md_no_indent_or_hash "
+    git-hooks allows you to invoke your hook scripts without being triggered by
+    a git action. This is useful for speeding up the process of debugging issues
+    that caused your hooks to fail in the first place. If you write your hook
+    scripts well, you can even pass extra arguments to your scripts that wouldn't
+    be present when being run from a git trigger. (eg. specifying a particular
+    unit test to speed up debugging).
+")
+
+$(md '###') Disable/enable particular hooks or hook scripts:
+$(md_no_indent_or_hash "
+    git-hooks gives you the ability to disable hooks down to the individual script
+    level. So if something is preventing a particular script from succeeding and
+    can be temporarily ignored, you can just disable that one and the other scripts
+    for that trigger will still apply. This is much better than $(md_inline_monospace --no-verify).
+")
+
+$(md '###') Hook repositories:
+$(md_no_indent_or_hash "
+    Rather than copying and pasting the same hook code into each of your
+    repositories, you can create a shared collection of hooks (as a git repo) and
+    simply reference those from within your repository. This way, as your hook
+    functionality evolves, you only need to push the code to the collection's
+    repo, and git-hooks will ensure that you pull down the latest.
+")
+
+$(md '###') Global hooks:
+$(md_no_indent_or_hash "
+    You can have "global hooks" on your machine. These will be run for any
+    repository that has git-hooks installed (ie. has the multiplexer scripts
+    in its $(md_inline_monospace .git/hooks) dir. See $(md_inline_bold Installation) below). This
+    is useful for applying consistent, project-agnostic rules across all of
+    your projects (such as commit message format/structure). These hooks can
+    be literal script files or reference hooks, but they will not be checked
+    into the source control of the repositories that they will affect. They
+    will appear and run alongside the repo's own hooks.
+
+    Global hooks will be enabled by default for all repos with git-hooks
+    installed. If you wish to prevent the global git hooks from running for
+    a repostiory, set the local git config value of $(md_inline_monospace "git-hooks.global-enabled")
+    to $(md_inline_monospace false). This will allow you to continue to use the repo's
+    source-controlled git hooks.
 ")
 
 $(md '##') Installation:
@@ -815,9 +870,12 @@ function git_hooks__get_hooks {
     local -a hook_names=( "${@:-${git_hook_names[@]}}" )
     local hook_dirs=""
     local hook_name total path name
+    local global_enabled
+
+    global_enabled=$(git config --bool git-hooks.global-enabled) || global_enabled=true
 
     [[ -d "$githooks_dir" ]] && hook_dirs="$hook_dirs $githooks_dir"
-    [[ -d "$global_githooks_dir" ]] && hook_dirs="$hook_dirs $global_githooks_dir"
+    "$global_enabled" && [[ -d "$global_githooks_dir" ]] && hook_dirs="$hook_dirs $global_githooks_dir"
     [[ -n "$hook_dirs" ]] || return
 
     for hook_name in "${hook_names[@]}"; do

--- a/git-hooks
+++ b/git-hooks
@@ -95,7 +95,17 @@ function git_hooks__ensure_gnu_getopt {
 }
 
 function git_hooks__ensure_collection {
-    local collections_path="${githooks_dir}/.collections"
+    local hooks_dir="$githooks_dir"
+
+    eval set -- "$($getopt -o g --long "global" -- "$@")"
+    while [[ $1 != -- ]]; do
+        case $1 in
+            -g|--global) hooks_dir="$global_githooks_dir"; shift;;
+        esac
+    done
+    shift
+
+    local collections_path="${hooks_dir}/.collections"
     local c_name="$1"
 
     [[ -d "${collections_path}/${c_name}" ]]
@@ -340,8 +350,9 @@ function git_hooks__require_git_dir {
 }
 
 
-function git_hooks__ensure_hook_dir {
+function git_hooks__ensure_hook_dirs {
     mkdir -p "$githooks_dir"
+    mkdir -p "$global_githooks_dir"
 }
 
 
@@ -520,11 +531,21 @@ function git_hooks_add_collection {
 
 	    <subpath to hooks>: The collection-relative path to the hook directories.
 	HELP
-    local c_name="$1" c_type="git" c_location="$2" c_subpath="${3:-}"
-    local git_hooks_config="${githooks_dir}/config"
-    local collections_path="${githooks_dir}/.collections"
+    local hooks_dir="$githooks_dir"
 
-    mkdir -p "$githooks_dir"
+    eval set -- "$($getopt -o g --long "global" -- "$@")"
+    while [[ $1 != -- ]]; do
+        case $1 in
+            -g|--global) hooks_dir="$global_githooks_dir"; shift;;
+        esac
+    done
+    shift
+
+    local git_hooks_config="${hooks_dir}/config"
+    local collections_path="${hooks_dir}/.collections"
+    local c_name="$1" c_type="git" c_location="$2" c_subpath="${3:-}"
+
+    mkdir -p "$hooks_dir"
 
     git config -f "$git_hooks_config" --unset-all collection.names "^${c_name}\$" &>/dev/null ||:
     git config -f "$git_hooks_config" --remove-section "collection.$c_name" &>/dev/null ||:
@@ -542,8 +563,19 @@ function git_hooks_add_collection {
 
 
 function git_hooks__sync_collection {
-    local git_hooks_config="${githooks_dir}/config"
-    local collections_path="${githooks_dir}/.collections"
+    git_hooks__ensure_gnu_getopt
+
+    local hooks_dir="$githooks_dir"
+    eval set -- "$($getopt -o g --long "global" -- "$@")"
+    while [[ $1 != -- ]]; do
+        case $1 in
+            -g|--global) hooks_dir="$global_githooks_dir"; shift;;
+        esac
+    done
+    shift
+
+    local git_hooks_config="${hooks_dir}/config"
+    local collections_path="${hooks_dir}/.collections"
     local c_name="$1" c_type c_location
 
     # Ensure we know about the collection
@@ -574,8 +606,7 @@ function git_hooks__sync_collection {
 
 function git_hooks_uninstall {
     : <<-HELP
-	    Removes the multiplexer hooks from the .git/hooks directory and
-	    removes the 'git-hooks' symlink from /usr/local/bin, if present.
+	    Removes the multiplexer hooks from the .git/hooks directory.
 	HELP
 
     printf "${c_action}%s${c_reset}\\n" "Removing multiplexers"
@@ -734,7 +765,7 @@ function git_hooks_list {
 	    List all hooks for the current repository and their runnable state.
 	HELP
 
-    local total count disabled unicode hook_name previous_hook_name hooks_list max_len=0 padding pad
+    local total count=0 disabled=false unicode hook_name previous_hook_name hooks_list max_len=0 padding pad
 
     unicode="$(git config --bool git-hooks.unicode)" || unicode=true
 
@@ -744,6 +775,8 @@ function git_hooks_list {
     done <<<"$hooks_list"
 
     while read -r total hook_name hook hook_path; do
+        [[ -n $total ]] || break
+
         echo -en "${c_reset}"
         if [[ "${previous_hook_name:-}" != "${hook_name}" ]]; then
             previous_hook_name="$hook_name"
@@ -785,11 +818,12 @@ function git_hooks_list {
 
 function git_hooks__get_hooks {
     local -a hook_names=( "${@:-${git_hook_names[@]}}" )
+    local hook_dirs=""
     local hook_name total path name
-    # local hook_scripts hook_script
-    # hook name path normalized disabled count total unicode connector
 
-    [[ -d "$githooks_dir" ]] || return
+    [[ -d "$githooks_dir" ]] && hook_dirs="$hook_dirs $githooks_dir"
+    [[ -d "$global_githooks_dir" ]] && hook_dirs="$hook_dirs $global_githooks_dir"
+    [[ -n "$hook_dirs" ]] || return
 
     for hook_name in "${hook_names[@]}"; do
         if ! git_hooks__is_git_hook "$hook_name"; then
@@ -797,13 +831,15 @@ function git_hooks__get_hooks {
             continue
         fi
 
-        total=$(find "$githooks_dir" -type f -path "*/${hook_name}*" -not -path "*/.collections/*" -not -name "*~" | wc -l)
+        # shellcheck disable=2086
+        total=$(find $hook_dirs -type f -path "*/${hook_name}*" -not -path "*/.collections/*" -not -name "*~" | wc -l)
 
+        # shellcheck disable=2086
         while read -r path; do
             name="${path##*${hook_name}}"
             name="${name:1:${#name}}"
             echo "$total $hook_name $name $path"
-        done < <(find "$githooks_dir" -type f -path "*/${hook_name}*" -not -path "*/.collections/*" -not -name "*~")
+        done < <(find $hook_dirs -type f -path "*/${hook_name}*" -not -path "*/.collections/*" -not -name "*~")
     done
 }
 
@@ -938,6 +974,10 @@ function git_hooks_run {
             path="${githooks_dir}/${name}"
         elif [[ -f "${githooks_dir}/${hook}/${name#${hook}-}" ]]; then
             path="${githooks_dir}/${hook}/${name#${hook}-}"
+        elif [[ -f "${global_githooks_dir}/${name}" ]]; then
+            path="${global_githooks_dir}/${name}"
+        elif [[ -f "${global_githooks_dir}/${hook}/${name#${hook}-}" ]]; then
+            path="${global_githooks_dir}/${hook}/${name#${hook}-}"
         else
             printf >&2 "${c_error}%s${c_reset}\\n" "Could not find hook or custom script"
             return 1
@@ -1061,16 +1101,26 @@ function git_hooks_include {
 	    <git hook>. Just provide a numeric prefix on the <new name> to indicate
 	    the script's place in the running order.
 	HELP
-    local git_hooks_config="${githooks_dir}/config"
-    local collections_path="${githooks_dir}/.collections"
+    local hooks_dir="$githooks_dir" global=''
+
+    eval set -- "$($getopt -o g --long "global" -- "$@")"
+    while [[ $1 != -- ]]; do
+        case $1 in
+            -g|--global) hooks_dir="$global_githooks_dir"; global='-g'; shift;;
+        esac
+    done
+    shift
+
+    local git_hooks_config="${hooks_dir}/config"
+    local collections_path="${hooks_dir}/.collections"
     local c_name="$1" hook_name="$2" hook="$3" as="${4:-}" c_location c_subpath="" c_subpath_tmp src_path path
 
     # Ensure we know about the collection
     git config -f "$git_hooks_config" --get collection.names "$c_name" &>/dev/null
     c_location=$(git config -f "$git_hooks_config" --get "collection.${c_name}.location")
 
-    git_hooks__sync_collection "$c_name"
-    git_hooks__ensure_collection "$c_name"
+    git_hooks__sync_collection "$global" "$c_name"
+    git_hooks__ensure_collection "$global" "$c_name"
 
     # Check the collection repo first, then allow overrides from local repo
     if c_subpath_tmp=$(git config -f "${collections_path}/${c_name}/.git-hooks-collection" --get "collection.subpath") 2>/dev/null; then
@@ -1087,11 +1137,12 @@ function git_hooks_include {
             return 1
         fi
 
-        path="${githooks_dir}/${hook_name}/${as:-${hook}}"
+        path="${hooks_dir}/${hook_name}/${as:-${hook}}"
         mkdir -p "$(dirname "$path")"
         printf '#!/usr/bin/env git-hooks\n\n' > "$path"
         git config -f "$path" git-hooks.collection "$c_name"
         git config -f "$path" git-hooks.hook "${hook_name}/${hook}"
+        [[ -n "$global" ]] && git config -f "$path" --bool git-hooks.global true
         chmod +x "$path"
         printf "${c_action}%s ${c_value}%s ${c_action}%s ${c_value}%s${c_reset}\\n" \
             "Linked" "${path#*\.githooks/}" "to" "${src_path#${collections_path}/}"
@@ -1124,6 +1175,7 @@ function git_hooks__check_for_updates {
 #############################################
 
 # Populated in _verify_dirs
+global_githooks_dir="$HOME/.githooks"
 git_dir="$(git rev-parse --git-dir 2>/dev/null)" || git_dir=""
 repo_dir="$(git rev-parse --show-toplevel 2>/dev/null)" || repo_dir=""
 repo_is_bare="$(git rev-parse --is-bare-repository 2>/dev/null)" || repo_is_bare=false
@@ -1153,18 +1205,13 @@ function git_hooks__main {
 
     # Determine the correct command to run and pass it the rest of the un-parsed options
     case "$git_hooks_command" in
-        # Require a git repository and a .githooks directory in the repository for these commands
-        list|include|disable|enable|run|parallel|show-input)
-            git_hooks__require_git_dir
-            git_hooks__ensure_hook_dir
-            ;;
-
-        # Require a git repository but not a .githooks directory in the repository
-        install|uninstall)
+        # Require a git repository for these commands
+        install|uninstall|list|disable|enable|run|parallel|show-input)
             git_hooks__require_git_dir
             ;;
 
-        add-collection|sync-collection|check-support|install-command|uninstall-command|install-template|uninstall-template|config|help)
+        # No special requirements
+        add-collection|sync-collection|check-support|install-command|uninstall-command|install-template|uninstall-template|config|help|include)
             ;;
 
         *)  printf >&2 "${c_error}%s ${c_value}%s ${c_error}%s${c_reset}\\n" "git-hooks:" "$git_hooks_command" "is not a git-hooks command." >&2
@@ -1179,16 +1226,26 @@ function git_hooks__main {
 #############################################
 function git_hooks__run_referenced_hook {
     # This function executes a "script" created by the "git hooks include" command
-    local hook_path c_name c_subpath git_hooks_config
-    local git_hooks_config="${githooks_dir}/config"
-    local collections_path="${githooks_dir}/.collections"
-
-    git_hooks_config="${githooks_dir}/config"
-    hook_path="$1"
+    local c_global c_name c_subpath
+    local hooks_dir
+    local git_hooks_config
+    local collections_path
+    local hook_path="$1"
     shift
 
+    c_global="$(git config -f "$hook_path" --bool --get git-hooks.global)" ||:
+    if [[ -n "$c_global" && "$c_global" ]]; then
+        hooks_dir=${global_githooks_dir}
+        c_global="-g"
+    else
+        hooks_dir=${githooks_dir}
+        c_global=""
+    fi
+
     c_name="$(git config -f "$hook_path" --get git-hooks.collection)"
-    c_subpath="$(git config -f "${githooks_dir}/config" --get "collection.${c_name}.subpath")" ||:
+    c_subpath="$(git config -f "${hooks_dir}/config" --get "collection.${c_name}.subpath")" ||:
+    git_hooks_config="${hooks_dir}/config"
+    collections_path="${hooks_dir}/.collections"
 
     # Check the collection repo first, then allow overrides from local repo
     if c_subpath_tmp=$(git config -f "${collections_path}/${c_name}/.git-hooks-collection" --get "collection.subpath") 2>/dev/null; then
@@ -1199,10 +1256,10 @@ function git_hooks__run_referenced_hook {
     fi
 
     # Retrieve/update the collection referenced in this config
-    git_hooks__sync_collection "$c_name"
-    git_hooks__ensure_collection "$c_name"
+    git_hooks__sync_collection "$c_global" "$c_name"
+    git_hooks__ensure_collection "$c_global" "$c_name"
 
-    "${githooks_dir}/.collections/${c_name}/${c_subpath:+${c_subpath}/}$(git config -f "$hook_path" --get git-hooks.hook)" "$@"
+    "${hooks_dir}/.collections/${c_name}/${c_subpath:+${c_subpath}/}$(git config -f "$hook_path" --get git-hooks.hook)" "$@"
 }
 
 # Determine if this file is being sourced or invoked

--- a/git-hooks
+++ b/git-hooks
@@ -350,12 +350,6 @@ function git_hooks__require_git_dir {
 }
 
 
-function git_hooks__ensure_hook_dirs {
-    mkdir -p "$githooks_dir"
-    mkdir -p "$global_githooks_dir"
-}
-
-
 function git_hooks__is_git_hook {
     local hook name="$1"
     for hook in "${git_hook_names[@]}"; do

--- a/git-hooks
+++ b/git-hooks
@@ -512,12 +512,13 @@ function git_hooks_install {
 
 function git_hooks_add_collection {
     : <<-ARGS
-	    <collection name> <clone url> [<subpath to hooks>]
+	    [-g|--global] <collection name> <clone url> [<subpath to hooks>]
 	ARGS
     : <<-HELP
 	    Configures this repository to be able to reference git hooks hosted
 	    in a remote locatior (currently only supports git repositories).
 
+        [-g|--global]:      The collection will be considered available to all repos
 	    <collection name>:  The internal name for the collection. Must be unique
 	                        within this repository.
 
@@ -1085,7 +1086,7 @@ HELP
 
 function git_hooks_include {
     : <<-ARGS
-	    <collection name> <git hook> <hook executable> [<new name>]
+	    [-g|--global] <collection name> <git hook> <hook executable> [<new name>]
 	ARGS
     : <<-HELP
 	    Link an existing script from a collection into this repository.
@@ -1094,6 +1095,12 @@ function git_hooks_include {
 	    wishes to specify a strict order to in which to run multiple scripts for
 	    <git hook>. Just provide a numeric prefix on the <new name> to indicate
 	    the script's place in the running order.
+
+        Specify '--global' if you want to reference a hook in a global collection.
+        Using this, it's possible to take advantage of project-agnostic hooks without
+        even placing them (or references to them) under your project's source control.
+        Bear in mind that some hooks will place files under the project's source
+        control as a side-effect of their behavior. This is to be expected.
 	HELP
     local hooks_dir="$githooks_dir" global=''
 

--- a/git-hooks-multiplexer
+++ b/git-hooks-multiplexer
@@ -127,12 +127,11 @@ disabled=
 nonexecutable=
 tmpfile=$(mktemp -t git_hooks.XXXX)
 count=0
-
 # Set a trap to clean up our temp file
 # shellcheck disable=2064
 trap "rm -f ${tmpfile}*" EXIT SIGHUP SIGINT SIGTERM
-
 # Collate our .githook scripts
+
 while read -r _ hook_name hook hook_path; do
     if { ! $GITHOOKS_RUN; } && { git config --get-regexp "hooks\\.$HOOK\\.enabled" false &>/dev/null \
             || git config --get-regexp "hooks\\.${hook_name}-${hook}\\.enabled" false &>/dev/null; }; then

--- a/included/hooks/commit-msg/format
+++ b/included/hooks/commit-msg/format
@@ -26,11 +26,7 @@ fi
 
 # Save the msg in case our commit fails and we want to preload it next time
 # in prepare-commit-msg-template.
-# Note: This filename format is mirrored in prepare-commit-msg-template, so be
-# sure to update that if you change these
-tmp_msg_prefix="git-commit-msg-$(basename $(git rev-parse --show-toplevel))"
-tmp_msg_filename="/tmp/${tmp_msg_prefix}-$(git rev-parse --short HEAD 2>/dev/null ||:)"
-cat "$commit_msg" >"$tmp_msg_filename"
+cat "$commit_msg" >"$(get_cached_commit_message_filename)"
 
 # Sentinel value set to false if any checks fail. This allows us to get output
 # from multiple failed checks.

--- a/included/hooks/commit-msg/jira-format
+++ b/included/hooks/commit-msg/jira-format
@@ -26,11 +26,7 @@ fi
 
 # Save the msg in case our commit fails and we want to preload it next time
 # in prepare-commit-msg-template.
-# Note: This filename format is mirrored in prepare-commit-msg-template, so be
-# sure to update that if you change these
-tmp_msg_prefix="git-commit-msg-$(basename "$(git rev-parse --show-toplevel)")"
-tmp_msg_filename="/tmp/${tmp_msg_prefix}-$(git rev-parse --short HEAD 2>/dev/null ||:)"
-cat "$commit_msg" >"$tmp_msg_filename"
+cat "$commit_msg" >"$(get_cached_commit_message_filename)"
 
 # Sentinel value set to false if any checks fail. This allows us to get output
 # from multiple failed checks.

--- a/included/hooks/post-commit/template-cleanup
+++ b/included/hooks/post-commit/template-cleanup
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -eu -o pipefail
+
+: <<DESC
+Delete the cached commit message file created by prepare-commit-msg/template
+DESC
+
+# Get our useful functions (be sure to provide lib path as source argument)
+# shellcheck source=included/lib/core.sh
+. "$(dirname "${BASH_SOURCE[@]}")/../../lib/core.sh" "$(dirname "${BASH_SOURCE[@]}")/../../lib"
+
+# Provide the previous commit, since that's what the commit message would have been associated with
+rm -f "$(get_cached_commit_message_filename HEAD~)"

--- a/included/hooks/prepare-commit-msg/template
+++ b/included/hooks/prepare-commit-msg/template
@@ -17,10 +17,7 @@ HELP
 # shellcheck source=included/lib/core.sh
 . "$(dirname "${BASH_SOURCE[@]}")/../../lib/core.sh" "$(dirname "${BASH_SOURCE[@]}")/../../lib"
 
-# This filename format is mirrored in commit-msg/format and commit-msg/jira-format,
-# so be sure to update that if you change these.
-tmp_msg_prefix="git-commit-msg-$(basename "$(git rev-parse --show-toplevel)")"
-tmp_msg_filename="/tmp/${tmp_msg_prefix}-$(git rev-parse --short HEAD 2>/dev/null ||:)"
+tmp_msg_filename="$(get_cached_commit_message_filename)"
 
 if [[ -n ${2:-} ]]; then
     # Don't use repo's .gitmessage if this is not a normal commit
@@ -32,8 +29,6 @@ elif [[ -f "$tmp_msg_filename" ]]; then
     # Use the previous message as a starting point
     mv "$tmp_msg_filename" "$1"
 
-    # Remove any lingering failed commit messages
-    rm -f "/tmp/${tmp_msg_prefix}-*"
 else
     if [[ ! -f .gitmessage ]]; then
         printf "${c_error}%s${c_value}%s${c_error}%s${c_reset}\\n\\n" "No " "$(basename "$(git rev-parse --show-toplevel)")/.gitmessage" " template file found"

--- a/included/lib/core.sh
+++ b/included/lib/core.sh
@@ -97,3 +97,12 @@ function move_to_branch () {
         fi
     fi
 }
+
+function get_cached_commit_message_filename {
+    local commit="${1:-HEAD}"
+    local repo="$(basename "$(git rev-parse --show-toplevel)")"
+    local branch="$(git rev-parse --abbrev-ref "$commit")"
+    local hash="$(git rev-parse --short "$commit" 2>/dev/null ||:)"
+
+    echo "/tmp/git-commit-msg-${repo}-${branch}-${hash}"
+}


### PR DESCRIPTION
One can now place hooks into their `~/.githooks` directory and they will be invoked for any repo that
has the multiplexers installed. This reduces clutter and maintenance in the code repos for tasks
that are largely project-agnostic.

[ENG-61](https://fivestars.atlassian.net/browse/ENG-61)