### PR TITLE
[ENG-63] Split the prepare-commit-msg/template into two hooks

### DIFF
--- a/included/hooks/commit-msg/format
+++ b/included/hooks/commit-msg/format
@@ -25,7 +25,7 @@ if [[ "$(sed -e '/^#.*/d' -e '/^$/d' "$commit_msg" | wc -l)" -eq 0 ]]; then
 fi
 
 # Save the msg in case our commit fails and we want to preload it next time
-# in prepare-commit-msg-template.
+# in a prepare-commit-msg hook..
 cat "$commit_msg" >"$(get_cached_commit_message_filename)"
 
 # Sentinel value set to false if any checks fail. This allows us to get output

--- a/included/hooks/commit-msg/jira-format
+++ b/included/hooks/commit-msg/jira-format
@@ -25,7 +25,7 @@ if [[ "$(sed -e '/^#.*/d' -e '/^$/d' "$commit_msg" | wc -l)" -eq 0 ]]; then
 fi
 
 # Save the msg in case our commit fails and we want to preload it next time
-# in prepare-commit-msg-template.
+# in a prepare-commit-msg hook.
 cat "$commit_msg" >"$(get_cached_commit_message_filename)"
 
 # Sentinel value set to false if any checks fail. This allows us to get output

--- a/included/hooks/post-commit/cached-cleanup
+++ b/included/hooks/post-commit/cached-cleanup
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -eu -o pipefail
+
+: <<DESC
+Delete the cached commit message file created by prepare-commit-msg hooks
+DESC
+
+# Get our useful functions (be sure to provide lib path as source argument)
+# shellcheck source=included/lib/core.sh
+. "$(dirname "${BASH_SOURCE[@]}")/../../lib/core.sh" "$(dirname "${BASH_SOURCE[@]}")/../../lib"
+
+# Provide the previous commit, since that's what the commit message will be associated with
+rm -f "$(get_cached_commit_message_filename HEAD~)"

--- a/included/hooks/post-commit/template-cleanup
+++ b/included/hooks/post-commit/template-cleanup
@@ -9,5 +9,9 @@ DESC
 # shellcheck source=included/lib/core.sh
 . "$(dirname "${BASH_SOURCE[@]}")/../../lib/core.sh" "$(dirname "${BASH_SOURCE[@]}")/../../lib"
 
+# Deprecation warning
+printf "${c_error}%s${c_reset}\\n" "post-commit/template-cleanup is deprecated."
+printf "${c_error}%s${c_reset}\\n" "Use post-commit/cached-cleanup instead."
+
 # Provide the previous commit, since that's what the commit message would have been associated with
 rm -f "$(get_cached_commit_message_filename HEAD~)"

--- a/included/hooks/prepare-commit-msg/cached
+++ b/included/hooks/prepare-commit-msg/cached
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+set -eu -o pipefail
+
+: <<DESC
+Restore a failed commit message, if present
+DESC
+
+: <<HELP
+If a previous commit at this HEAD fails due to a 'commit-msg-format' failure,
+this hook will reload the failed message for usage/editing in the hooked commit.
+HELP
+
+# Get our useful functions (be sure to provide lib path as source argument)
+# shellcheck source=included/lib/core.sh
+. "$(dirname "${BASH_SOURCE[@]}")/../../lib/core.sh" "$(dirname "${BASH_SOURCE[@]}")/../../lib"
+
+clear_cached_commit_message_in_use
+
+case "${2:-}" in
+    # Normal commit
+    ""|template) ;;
+
+    # Unhandled commit types
+    *) exit 0 ;;
+esac
+
+tmp_msg_filename="$(get_cached_commit_message_filename)"
+if [[ -f "$tmp_msg_filename" ]]; then
+    # Found the failed commit message created by commit-msg-format
+    printf "${c_action}%s${c_reset}\\n" "Found previous commit message for these changes:"
+    cat "$tmp_msg_filename"
+    echo
+
+    printf "${c_prompt}%s${c_reset}" "Use this commit message? ([y]es/[n]o/[d]iscard): "
+    read -r response
+    case $response in
+        n|no) exit 0 ;;
+        d|discard) rm "$tmp_msg_filename"; exit 0 ;;
+        *)  ;;
+    esac
+
+    # Use the previous message as a starting point
+    set_cached_commit_message_in_use "$tmp_msg_filename" "$1"
+fi

--- a/included/hooks/prepare-commit-msg/jira
+++ b/included/hooks/prepare-commit-msg/jira
@@ -9,28 +9,29 @@ DESC
 For commit messages that contain the '\$JIRA' string, this will derive the Jira
 issue id from the branch name, or failing that, prompt the user to manually enter
 the issue id. It then applies that issue id to the commit message, substituting
-all '\$JIRA' instances with the issue id.
+all '\$JIRA' instances with the issue id prior to prompting the user to edit the
+commit message.
 HELP
 
 # Get our useful functions (be sure to provide lib path as source argument)
 # shellcheck source=included/lib/jira.sh
 . "$(dirname "${BASH_SOURCE[@]}")/../../lib/jira.sh" "$(dirname "${BASH_SOURCE[@]}")/../../lib"
 
-if [[ -n ${2:-} ]]; then
-  # Don't apply this process if this is not a normal commit
-  exit
-elif grep -q "\$JIRA" "$1"; then
-  # Found a commit message that could use a Jira ticket substitution
+# No need to do anything if we're using a previously rejected commit message
+is_cached_commit_message_in_use && exit
 
-  # Get our Jira issue id and substitute it for $JIRA in the received commit message
-  if branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null); then
-    jira_ticket=$(jira_get_ticket_from_branch_name "$branch" || jira_get_ticket)
-  else
-    jira_ticket=$(jira_get_ticket)
-  fi
+# Look for commit messages that could use a Jira ticket substitution
+if grep -q "\$JIRA" "$1"; then
 
-  printf "${c_action}%s ${c_value}%s ${c_action}%s${c_reset}\\n" "Applying Jira ticket" "$jira_ticket" "to commit message"
-  tmpfile=$(mktemp -t git-commit-msg-template.XXXX); trap 'rm -f $tmpfile' EXIT
-  JIRA="$jira_ticket" envsubst "\$JIRA" <"$1" >"$tmpfile"
-  mv "$tmpfile" "$1"
+    # Get our Jira issue id and substitute it for $JIRA in the received commit message
+    if branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null); then
+        jira_ticket=$(jira_get_ticket_from_branch_name "$branch" || jira_get_ticket)
+    else
+        jira_ticket=$(jira_get_ticket)
+    fi
+
+    printf "${c_action}%s ${c_value}%s ${c_action}%s${c_reset}\\n" "Applying Jira ticket" "$jira_ticket" "to commit message"
+    tmpfile=$(mktemp -t git-commit-msg-template.XXXX); trap 'rm -f $tmpfile' EXIT
+    JIRA="$jira_ticket" envsubst "\$JIRA" <"$1" >"$tmpfile"
+    mv "$tmpfile" "$1"
 fi

--- a/included/hooks/prepare-commit-msg/subject
+++ b/included/hooks/prepare-commit-msg/subject
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+set -eu -o pipefail
+
+: <<DESC
+Inject the commit message into a commit message template that contains the '\$SUBJECT' placeholder
+DESC
+
+: <<HELP
+If the commit is using a message template (via "commit -t", or the
+"commit.template" config value) and the commit message was provided
+at the command-line with "-m <message>", use the template and substitute
+any '\$SUBJECT' placeholders in the template with the provided "<message>".
+
+If the template is not provided, or the template does not contain any
+'\$SUBJECT' placeholders, this hook will have no effect.
+HELP
+
+# Get our useful functions (be sure to provide lib path as source argument)
+# shellcheck source=included/lib/core.sh
+. "$(dirname "${BASH_SOURCE[@]}")/../../lib/core.sh" "$(dirname "${BASH_SOURCE[@]}")/../../lib"
+
+# No need to do anything if we're using a previously rejected commit message
+is_cached_commit_message_in_use && exit
+
+case "${2:-}" in
+    # Look for commits with a message provided by -m at command-line.
+    # This means git will not prompt us to further edit the message.
+    message)
+        [[ -f .git/CHERRY_PICK_HEAD ]] && exit
+
+        # We will need to manually apply the template, so let's verify that it exists
+        template="$(git config commit.template)" && [[ -f "$template" ]] || exit
+
+        # Read in the provided message
+        read -r -d '' message <"$1" ||:
+
+        # Create a temporary file to assist with manipulations
+        tmpfile=$(mktemp -t git-commit-msg-template.XXXX); trap 'rm -f $tmpfile' EXIT
+
+        # Remove comments from template, since we won't be sending it through
+        # the editor flow where git would do this for us automatically.
+        # Then inject the $message into the $SUBJECT placeholder (if present).
+        sed -e 's/^#.*//g' "$template" \
+        | uniq \
+        | SUBJECT="$message" envsubst "\$SUBJECT" \
+        >"$1"
+
+        ;;
+
+    # We didn't receive a message yet, but we have a template. This means git
+    # will prompt the user to edit the message. Let's strip out the $SUBJECT
+    # placeholder (if present).
+    template)
+        tmpfile=$(mktemp -t git-commit-msg-template.XXXX); trap 'rm -f $tmpfile' EXIT
+        SUBJECT="" envsubst "\$SUBJECT" <"$1" >"$tmpfile"
+        mv "$tmpfile" "$1"
+        ;;
+
+    # Unhandled commit types
+    *) exit 0
+        ;;
+esac

--- a/included/hooks/prepare-commit-msg/template
+++ b/included/hooks/prepare-commit-msg/template
@@ -61,6 +61,10 @@ else
         esac
     fi
 
+    # Deprecation warning
+    printf "${c_error}%s${c_reset}\\n" "prepare-commit-msg/template is deprecated."
+    printf "${c_error}%s${c_reset}\\n" "Use prepare-commit-msg/cached and prepare-commit-msg/subject instead."
+
     # Found a .gitmessage file in our repo
     printf "${c_action}%s${c_reset}\\n" "Using $(basename "$(git rev-parse --show-toplevel)")/.gitmessage template"
 

--- a/included/lib/core.sh
+++ b/included/lib/core.sh
@@ -106,3 +106,16 @@ function get_cached_commit_message_filename {
 
     echo "/tmp/git-commit-msg-${repo}-${branch}-${hash}"
 }
+
+function clear_cached_commit_message_in_use {
+    rm -f .git/CACHED_COMMIT_MSG
+}
+
+function set_cached_commit_message_in_use {
+    cp "$1" .git/CACHED_COMMIT_MSG
+    mv "$1" "$2"
+}
+
+function is_cached_commit_message_in_use {
+    [[ -f .git/CACHED_COMMIT_MSG ]]
+}


### PR DESCRIPTION
Split the `prepare-commit-msg/template` into two hooks: `prepare-commit-msg/cached` and
`prepare-commit-msg/subject`.

The `cached` hook will check for any commit messages stored by a later hook during downstream
validation (during a previous commit attempt). If found, it will display the contents of the
cached message and prompt the user to use it, ignore it, or discard it. Ignoring it will leave
the cached message in place for later attempts, but discarding it will remove it completely.

The `subject` hook enables one to provide the commit message on the command-line with the
`git commit -m "<message>"` option and still get the benefits of using a commit message template.
One usually provides a template with the `commit.template` git config value. If the template
contains the `$SUBJECT` placeholder, the provided message will be substituted there. If no message
is provided at the command-line, this hook simply removes the `$SUBJECT` placeholder prior to the
message being presented to the user for editing.

Prior to these changes, it was assumed that the commit template file could be found at
`<repo-root>/.gitmessage`. However, we now rely on the user leveraging existing git functionality
and providing the commit message template by conventional means. This means that one may also
specify a global commit message template, say in their home directory, and have it applied to all git
repos on their machine. This, combined with the global git hooks, make for a consistent experience
all around.

We are also renaming `post-commit/template-cleanup` to `post-commit/cached-cleanup` to match
the new `prepare-commit-msg/cached-cleanup`.

Furthermore, `prepare-commit-msg/template` and `post-commit/template-cleanup` now display
deprecation warnings (but otherwise remain functional).

[ENG-63](https://fivestars.atlassian.net/browse/ENG-63)