### PR TITLE
[ENG-64] Fix is_protected_branch on mac

### DIFF
--- a/included/lib/core.sh
+++ b/included/lib/core.sh
@@ -25,9 +25,9 @@ function is_protected_branch () {
         protected="$(xargs <.protected)"
     fi
     protected="${protected:-master}"
-    protected="^${protected// /\$\\|\^}\$"
+    protected="^${protected// /\$|^}\$"
 
-    grep -q "$protected" <<<"$1"
+    grep -qE "$protected" <<<"$1"
 }
 
 function open_uri () {


### PR DESCRIPTION
We need to use egrep (-E) syntax here, too.

[ENG-64](https://fivestars.atlassian.net/browse/ENG-64)