### PR TITLE
[ENG-83] Add output to prepare-commit-msg hooks when they are skipped

### DIFF
--- a/included/hooks/prepare-commit-msg/cached
+++ b/included/hooks/prepare-commit-msg/cached
@@ -16,12 +16,35 @@ HELP
 
 clear_cached_commit_message_in_use
 
+# Decide how to proceed based on the commit type
 case "${2:-}" in
-    # Normal commit
-    ""|template) ;;
 
-    # Unhandled commit types
-    *) exit 0 ;;
+    # Debugging (git hooks run prepare-commit-msg...)
+    "") ;;
+
+    # Normal commit without message content yet; the editor will be opened
+    template) ;;
+
+    ## Unhandled commit types:
+    # Message was provided via -m or -F
+    message) printf "${c_action}%s${c_reset}\\n" "Commit message provided already, nothing to be done"
+             exit 0 ;;
+
+    # This is a merge commit message
+    merge) printf "${c_action}%s${c_reset}\\n" "Merge commit message provided, nothing to be done"
+           exit 0 ;;
+
+    # This commit is being squashed, most likely during a rebase
+    squash) printf "${c_action}%s${c_reset}\\n" "Squashing commit message, nothing to be done"
+            exit 0 ;;
+
+    # The commit message contents are already complete
+    commit) printf "${c_action}%s${c_reset}\\n" "Using existing commit message, nothing to be done"
+            exit 0 ;;
+
+    # Unexpected commit message type
+    *)  printf "${c_warning}%s${c_value}%s${c_warning}%s${c_reset}\\n" "Unexpected commit message type " "${2:-}" ", skipping hook:"
+        exit 0 ;;
 esac
 
 tmp_msg_filename="$(get_cached_commit_message_filename)"

--- a/included/hooks/prepare-commit-msg/jira
+++ b/included/hooks/prepare-commit-msg/jira
@@ -26,6 +26,38 @@ HELP
 # No need to do anything if we're using a previously rejected commit message
 is_cached_commit_message_in_use && exit
 
+# Decide how to proceed based on the commit type
+case "${2:-}" in
+
+    # Debugging (git hooks run prepare-commit-msg...)
+    "") ;;
+
+    # Normal commit without message content yet; the editor will be opened
+    template) ;;
+
+    ## Unhandled commit types:
+    # Message was provided via -m or -F
+    message) printf "${c_action}%s${c_reset}\\n" "Commit message provided already, nothing to be done"
+             exit 0 ;;
+
+    # This is a merge commit message
+    merge) printf "${c_action}%s${c_reset}\\n" "Merge commit message provided, nothing to be done"
+           exit 0 ;;
+
+    # This commit is being squashed, most likely during a rebase
+    squash) printf "${c_action}%s${c_reset}\\n" "Squashing commit message, nothing to be done"
+            exit 0 ;;
+
+    # The commit message contents are already complete
+    commit) printf "${c_action}%s${c_reset}\\n" "Using existing commit message, nothing to be done"
+            exit 0 ;;
+
+    # Unexpected commit message type
+    *)  printf "${c_warning}%s${c_value}%s${c_warning}%s${c_reset}\\n" "Unexpected commit message type " "${2:-}" ", skipping hook:"
+        exit 0 ;;
+esac
+
+
 # Look for commit messages that could use a Jira ticket substitution
 if grep -q "\$JIRA\\|\${JIRA}" "$1"; then
 

--- a/included/hooks/prepare-commit-msg/subject
+++ b/included/hooks/prepare-commit-msg/subject
@@ -24,10 +24,12 @@ HELP
 # No need to do anything if we're using a previously rejected commit message
 is_cached_commit_message_in_use && exit
 
+# Decide how to proceed based on the commit type
 case "${2:-}" in
     # Look for commits with a message provided by -m at command-line.
     # This means git will not prompt us to further edit the message.
     message)
+        # Don't bother if this is a cherry-pick
         [[ -f .git/CHERRY_PICK_HEAD ]] && exit
 
         # We will need to manually apply the template, so let's verify that it exists
@@ -58,7 +60,20 @@ case "${2:-}" in
         mv "$tmpfile" "$1"
         ;;
 
-    # Unhandled commit types
-    *) exit 0
-        ;;
+    ## Unhandled commit types:
+    # This is a merge commit message
+    merge) printf "${c_action}%s${c_reset}\\n" "Merge commit message provided, nothing to be done"
+           exit 0 ;;
+
+    # This commit is being squashed, most likely during a rebase
+    squash) printf "${c_action}%s${c_reset}\\n" "Squashing commit message, nothing to be done"
+            exit 0 ;;
+
+    # The commit message contents are already complete
+    commit) printf "${c_action}%s${c_reset}\\n" "Using existing commit message, nothing to be done"
+            exit 0 ;;
+
+    # Unexpected commit message type
+    *)  printf "${c_warning}%s${c_value}%s${c_warning}%s${c_reset}\\n" "Unexpected commit message type " "${2:-}" ", skipping hook:"
+        exit 0 ;;
 esac

--- a/included/lib/core.sh
+++ b/included/lib/core.sh
@@ -5,6 +5,7 @@
 
 # Themed colors - export these in your shell to override
 c_good="${c_good:-${green}}"
+c_warning="${c_warning:-${b_red}}"
 c_error="${c_error:-${red}}"
 c_prompt="${c_prompt:-${b_cyan}}"
 c_action="${c_action:-${cyan}}"


### PR DESCRIPTION
`prepare-commit-msg` hooks get some input values that help indicate what
operation is occurring that requires a commit message to be created or edited.
This uses these values to determine when no work should take place for the hook
and have the hook report that it is being skipped and why.

https://git-scm.com/docs/githooks#_prepare_commit_msg

[ENG-83](https://fivestars.atlassian.net/browse/ENG-83)