### PR TITLE
[ENG-84] Update Jira hooks to allow initial commit in brand-new repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,21 +2,27 @@
 A tool for managing and invoking custom git hook scripts.
 
 ## Description:
- git-hooks is a tool to facilitate git hook management, specifically being able to store your hooks under source control within the repository itself and simply reference them from a multiplexer hook installed in the `.git/hooks` directory.  The expected usage is to write an arbitrary number of individual hook scripts associated with a single standard git hook and store them in the `.githooks` directory. When git invokes the multiplexer script in `.git/hooks`, it will call your custom scripts sequentially, or in parallel if you configure it to do so.  This way you can break your monolithic hooks into individual files, giving you greater flexibility regarding which pieces to run and when.  
+ **git-hooks** is a tool to facilitate git hook management, specifically being able to store your hooks under source control within the repository itself and simply reference them from a multiplexer hook installed in the `.git/hooks` directory.  
+
+ The expected usage is to write an arbitrary number of individual hook scripts associated with a single standard git hook and store them in the `.githooks` directory. When git invokes the multiplexer script in `.git/hooks`, it will call your custom scripts sequentially, or in parallel if you configure it to do so.  
+
+ This way you can break your monolithic hooks into individual files, giving you greater flexibility regarding which pieces to run and when.  
 
 ## Features:
 
 ### Run your hooks directly:
- git-hooks allows you to invoke your hook scripts without being triggered by a git action. This is useful for speeding up the process of debugging issues that caused your hooks to fail in the first place. If you write your hook scripts well, you can even pass extra arguments to your scripts that wouldn't be present when being run from a git trigger. (eg. specifying a particular unit test to speed up debugging).  
+ **git-hooks** allows you to invoke your hook scripts without being triggered by a git action. This is useful for speeding up the process of debugging issues that caused your hooks to fail in the first place. If you write your hook scripts well, you can even pass extra arguments to your scripts that wouldn't be present when being run from a git trigger. (eg. specifying a particular unit test to speed up debugging).  
 
 ### Disable/enable particular hooks or hook scripts:
- git-hooks gives you the ability to disable hooks down to the individual script level. So if something is preventing a particular script from succeeding and can be temporarily ignored, you can just disable that one and the other scripts for that trigger will still apply. This is much better than `--no-verify`.  
+ **git-hooks** gives you the ability to disable hooks down to the individual script level. So if something is preventing a particular script from succeeding and can be temporarily ignored, you can just disable that one and the other scripts for that trigger will still apply. This is much better than `--no-verify`.  
 
 ### Hook repositories:
- Rather than copying and pasting the same hook code into each of your repositories, you can create a shared collection of hooks (as a git repo) and simply reference those from within your repository. This way, as your hook functionality evolves, you only need to push the code to the collection's repo, and git-hooks will ensure that you pull down the latest.  
+ Rather than copying and pasting the same hook code into each of your repositories, you can create a shared collection of hooks (as a git repo) and simply reference those from within your repository. This way, as your hook functionality evolves, you only need to push the code to the collection's repo, and **git-hooks** will ensure that you pull down the latest.  
 
 ### Global hooks:
- You can have global hooks on your machine. These will be run for any repository that has git-hooks installed (ie. has the multiplexer scripts in its `.git/hooks` dir. See **Installation** below). This is useful for applying consistent, project-agnostic rules across all of your projects (such as commit message format/structure). These hooks can be literal script files or reference hooks, but they will not be checked into the source control of the repositories that they will affect. They will appear and run alongside the repo's own hooks.  Global hooks will be enabled by default for all repos with git-hooks installed. If you wish to prevent the global git hooks from running for a repostiory, set the local git config value of `git-hooks.global-enabled` to `false` within the repository. This will allow you to continue to use the repo's source-controlled git hooks.  
+ You can have global hooks on your machine. These will be run for any repository that has **git-hooks** installed (ie. has the multiplexer scripts in its `.git/hooks` dir. See **Installation** below). This is useful for applying consistent, project-agnostic rules across all of your projects (such as commit message format/structure). These hooks can be literal script files or reference hooks, but they will not be checked into the source control of the repositories that they will affect. They will appear and run alongside the repo's own hooks.  
+
+ Global hooks will be enabled by default for all repos with **git-hooks** installed. If you wish to prevent the global git hooks from running for a repostiory, set the local git config value of `git-hooks.global-enabled` to `false` within the repository. This will allow you to continue to use the repo's source-controlled git hooks.  
 
 ## Installation:
 
@@ -190,10 +196,10 @@ A tool for managing and invoking custom git hook scripts.
         Removes the multiplexer hooks from the .git/hooks directory.
 
     install-command 
-        Creates a symlink to 'git-hooks' in /usr/local/bin
+        Creates a symlink to git-hooks in /usr/local/bin
 
     uninstall-command 
-        Removes the symlink to 'git-hooks' in /usr/local/bin, if present.
+        Removes the symlink to git-hooks in /usr/local/bin, if present.
 
     install-template 
         Installs the multiplexer scripts into ~/.gittemplate/hooks (or

--- a/git-hooks
+++ b/git-hooks
@@ -222,17 +222,21 @@ $(md_omit "git-hooks - ")A tool for managing and invoking custom git hook script
 
 $(md '##') Description:
 $(md_no_indent_or_hash "
-    git-hooks is a tool to facilitate git hook management, specifically being
+    $(md_inline_bold git-hooks) is a tool to facilitate git hook management, specifically being
     able to store your hooks under source control within the repository itself
     and simply reference them from a multiplexer hook installed in the
     $(md_inline_monospace .git/hooks) directory.
+")
 
+$(md_no_indent_or_hash "
     The expected usage is to write an arbitrary number of individual hook
     scripts associated with a single standard git hook and store them in the
     $(md_inline_monospace '.githooks') directory. When git invokes the multiplexer script in $(md_inline_monospace .git/hooks),
     it will call your custom scripts sequentially, or in parallel if you
     configure it to do so.
+")
 
+$(md_no_indent_or_hash "
     This way you can break your monolithic hooks into individual files, giving
     you greater flexibility regarding which pieces to run and when.
 ")
@@ -241,7 +245,7 @@ $(md '##') Features:
 
 $(md '###') Run your hooks directly:
 $(md_no_indent_or_hash "
-    git-hooks allows you to invoke your hook scripts without being triggered by
+    $(md_inline_bold git-hooks) allows you to invoke your hook scripts without being triggered by
     a git action. This is useful for speeding up the process of debugging issues
     that caused your hooks to fail in the first place. If you write your hook
     scripts well, you can even pass extra arguments to your scripts that wouldn't
@@ -251,7 +255,7 @@ $(md_no_indent_or_hash "
 
 $(md '###') Disable/enable particular hooks or hook scripts:
 $(md_no_indent_or_hash "
-    git-hooks gives you the ability to disable hooks down to the individual script
+    $(md_inline_bold git-hooks) gives you the ability to disable hooks down to the individual script
     level. So if something is preventing a particular script from succeeding and
     can be temporarily ignored, you can just disable that one and the other scripts
     for that trigger will still apply. This is much better than $(md_inline_monospace --no-verify).
@@ -263,21 +267,23 @@ $(md_no_indent_or_hash "
     repositories, you can create a shared collection of hooks (as a git repo) and
     simply reference those from within your repository. This way, as your hook
     functionality evolves, you only need to push the code to the collection's
-    repo, and git-hooks will ensure that you pull down the latest.
+    repo, and $(md_inline_bold git-hooks) will ensure that you pull down the latest.
 ")
 
 $(md '###') Global hooks:
 $(md_no_indent_or_hash "
     You can have "global hooks" on your machine. These will be run for any
-    repository that has git-hooks installed (ie. has the multiplexer scripts
+    repository that has $(md_inline_bold git-hooks) installed (ie. has the multiplexer scripts
     in its $(md_inline_monospace .git/hooks) dir. See $(md_inline_bold Installation) below). This
     is useful for applying consistent, project-agnostic rules across all of
     your projects (such as commit message format/structure). These hooks can
     be literal script files or reference hooks, but they will not be checked
     into the source control of the repositories that they will affect. They
     will appear and run alongside the repo's own hooks.
+")
 
-    Global hooks will be enabled by default for all repos with git-hooks
+$(md_no_indent_or_hash "
+    Global hooks will be enabled by default for all repos with $(md_inline_bold git-hooks)
     installed. If you wish to prevent the global git hooks from running for
     a repostiory, set the local git config value of $(md_inline_quotes "git-hooks.global-enabled")
     to $(md_inline_quotes false) within the repository. This will allow you to continue
@@ -763,7 +769,7 @@ function git_hooks_install_command {
     : <<-ARGS
 	ARGS
     : <<-HELP
-	    Creates a symlink to 'git-hooks' in /usr/local/bin
+	    Creates a symlink to git-hooks in /usr/local/bin
 	HELP
 
     if ! ln -isv "${bash_source}" "/usr/local/bin"; then
@@ -780,7 +786,7 @@ function git_hooks_uninstall_command {
     : <<-ARGS
 	ARGS
     : <<-HELP
-	    Removes the symlink to 'git-hooks' in /usr/local/bin, if present.
+	    Removes the symlink to git-hooks in /usr/local/bin, if present.
 	HELP
 
     rm -f /usr/local/bin/git-hooks

--- a/included/hooks/pre-commit/jira-branch-name
+++ b/included/hooks/pre-commit/jira-branch-name
@@ -19,7 +19,7 @@ HELP
 # shellcheck source=included/lib/jira.sh
 . "$(dirname "${BASH_SOURCE[@]}")/../../lib/jira.sh" "$(dirname "${BASH_SOURCE[@]}")/../../lib"
 
-branch=$(git rev-parse --abbrev-ref HEAD)
+branch=$(git symbolic-ref --short HEAD)
 if (( $# )); then
     move_to_branch "$(jira_ensure_conforming_branch_name "$(jira_get_new_branch_name)")"
 elif ! is_protected_branch "$branch"; then

--- a/included/hooks/pre-commit/jira-protect-branch
+++ b/included/hooks/pre-commit/jira-protect-branch
@@ -15,13 +15,19 @@ HELP
 # shellcheck source=included/lib/jira.sh
 . "$(dirname "${BASH_SOURCE[@]}")/../../lib/jira.sh" "$(dirname "${BASH_SOURCE[@]}")/../../lib"
 
-branch=$(git rev-parse --abbrev-ref HEAD)
+branch=$(git symbolic-ref --short HEAD)
 
 if is_protected_branch "$branch"; then
     printf "${c_prompt}%s${c_reset}" "Do you really want to commit directly to protected branch \"$branch\"? ([y]es/[n]o): "
     read -r response
     case $response in
         yes|y)  ;;
-        *)      move_to_branch "$(jira_ensure_conforming_branch_name "$(jira_get_new_branch_name)")" ;;
+        *)
+            if [[ "${branch}" == "master" ]] && ! git rev-parse --verify --quiet master; then
+                # This appears to be a brand new repository and we're commiting our first commit.
+                # Go ahead and create the branch so we can have a base for our new feature branch.
+                git checkout -b master &>/dev/null
+            fi
+            move_to_branch "$(jira_ensure_conforming_branch_name "$(jira_get_new_branch_name)")" ;;
     esac
 fi

--- a/included/hooks/prepare-commit-msg/jira
+++ b/included/hooks/prepare-commit-msg/jira
@@ -62,7 +62,7 @@ esac
 if grep -q "\$JIRA\\|\${JIRA}" "$1"; then
 
     # Get our Jira issue id and substitute it for $JIRA in the received commit message
-    if branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null); then
+    if branch=$(git symbolic-ref --short HEAD 2>/dev/null); then
         jira_ticket=$(jira_get_ticket_from_branch_name "$branch" || jira_get_ticket)
     else
         jira_ticket=$(jira_get_ticket)
@@ -92,7 +92,7 @@ if grep -q "\$JIRA\\|\${JIRA}" "$1"; then
 
         # Also, don't bother if the previous commit already has info for the current issue.
         # Just remove the placeholders.
-        if git log -n 1 --no-merges --first-parent | grep -q "\\[$jira_ticket\\]" &>/dev/null; then
+        if git log -n 1 --no-merges --first-parent 2>/dev/null | grep -q "\\[$jira_ticket\\]"; then
             JIRA_SUMMARY="" JIRA_DESC="" envsubst "\$JIRA_SUMMARY \$JIRA_DESC" <"$1" >"$tmpfile"
             cp "$tmpfile" "$1"
             exit

--- a/included/lib/core.sh
+++ b/included/lib/core.sh
@@ -75,16 +75,16 @@ function move_to_branch () {
     # Stderr: <none>
     local response branch new_branch="$1"
 
-    branch="$(git rev-parse --abbrev-ref HEAD)"
+    branch="$(git symbolic-ref --short HEAD)"
 
     if [[ "$new_branch" != "$branch" ]]; then
         printf "\\n${c_action}%s ${c_value}%s${c_reset}\\n" "Moving to new branch:" "$new_branch"
 
         # This will succeed but return error code 1 during a commit, hence the ||:
-        git checkout -b "$new_branch" ||:
+        git checkout -b "$new_branch" | grep -v "Switched to a new branch" ||:
 
         # Only continue if we created and checked out the new branch
-        [[ "$(git rev-parse --abbrev-ref HEAD)" == "$new_branch" ]]
+        [[ "$(git symbolic-ref --short HEAD)" == "$new_branch" ]]
 
         # Clean up old branch?
         if ! is_protected_branch "$branch"; then
@@ -102,8 +102,8 @@ function move_to_branch () {
 function get_cached_commit_message_filename {
     local commit="${1:-HEAD}"
     local repo="$(basename "$(git rev-parse --show-toplevel)")"
-    local branch="$(git rev-parse --abbrev-ref "$commit")"
-    local hash="$(git rev-parse --short "$commit" 2>/dev/null ||:)"
+    local branch="$(git rev-parse --abbrev-ref "$commit" 2>/dev/null)"
+    local hash="$(git rev-parse --short "$commit" 2>/dev/null)"
 
     echo "/tmp/git-commit-msg-${repo}-${branch}-${hash}"
 }


### PR DESCRIPTION
We used to use some git operations that tried to determine the commit info of HEAD, which doesn't
exist in a newly-init'ed repository. These changes swap them out for a safer alternative.

[ENG-84](https://fivestars.atlassian.net/browse/ENG-84)