### PR TITLE
[ENG-87] Don't display current git branch in jira-protect-branch

### DIFF
--- a/included/hooks/pre-commit/jira-protect-branch
+++ b/included/hooks/pre-commit/jira-protect-branch
@@ -23,7 +23,7 @@ if is_protected_branch "$branch"; then
     case $response in
         yes|y)  ;;
         *)
-            if [[ "${branch}" == "master" ]] && ! git rev-parse --verify --quiet master; then
+            if [[ "${branch}" == "master" ]] && ! git rev-parse --verify --quiet master &>/dev/null; then
                 # This appears to be a brand new repository and we're commiting our first commit.
                 # Go ahead and create the branch so we can have a base for our new feature branch.
                 git checkout -b master &>/dev/null


### PR DESCRIPTION
Apparently `git rev-parse --verify --quiet master` isn't actually quiet when
the master branch exists. This fixes that.

[ENG-87](https://fivestars.atlassian.net/browse/ENG-87)