### PR TITLE
[ENG-85] Allow non-Jira-based named branches for unticketed work

### DIFF
--- a/included/hooks/commit-msg/jira-format
+++ b/included/hooks/commit-msg/jira-format
@@ -14,18 +14,22 @@ DESC
 
 commit_msg="$1"
 
-# Lets just send all output to stderr
-exec >&2
-
-if [[ -f $(git rev-parse --git-dir)/MERGE_HEAD ]]; then
-    # This is a merge commit, don't enforce rules
-    exit
-fi
-
 if [[ "$(sed -e '/^#.*/d' -e '/^$/d' "$commit_msg" | wc -l)" -eq 0 ]]; then
     # Allow git commit to abort normally on an empty commit message
     exit
+elif [[ -f $(git rev-parse --git-dir)/MERGE_HEAD ]]; then
+    # This is a merge commit, don't enforce rules
+    exit
+elif ! branch=$(git symbolic-ref --short HEAD 2>/dev/null); then
+    # Commit is not on a branch (or is the first commit in a repo)
+    exit
+elif ! jira_is_valid_ticket_branch_name "$branch"; then
+    # This is unticketed work, don't bother with the format checks
+    exit
 fi
+
+# Lets just send all output to stderr
+exec >&2
 
 # Save the msg in case our commit fails and we want to preload it next time
 # in a prepare-commit-msg hook.

--- a/included/hooks/prepare-commit-msg/jira
+++ b/included/hooks/prepare-commit-msg/jira
@@ -62,12 +62,31 @@ if grep -q "\$JIRA\\|\${JIRA}" "$1"; then
 
     # Get our Jira issue id and substitute it for $JIRA in the received commit message
     if branch=$(git symbolic-ref --short HEAD 2>/dev/null); then
-        jira_ticket=$(jira_get_ticket_from_branch_name "$branch" || jira_get_ticket)
+        if jira_ticket="$(jira_get_ticket_from_branch_name "$branch")"; then
+            ticketed=true
+        else
+            ticketed=false
+            jira_ticket="$branch"
+        fi
     else
+        ticketed=true
         jira_ticket=$(jira_get_ticket)
+        if [[ "$jira_ticket" == "-" ]]; then
+            ticketed=false
+            jira_ticket="$branch"
+        fi
     fi
 
     tmpfile=$(mktemp -t git-commit-msg-template.XXXX); trap 'rm -f $tmpfile' EXIT
+
+    # If the work is unticketed, blank out any JIRA substitions
+    if ! "$ticketed"; then
+        # sed -e "/^.*\${\\?JIRA.*$/d" "$1" >"$tmpfile"
+        # cp "$tmpfile" "$1"
+        JIRA="" JIRA_SUMMARY="" JIRA_DESC="" envsubst "\$JIRA \$JIRA_SUMMARY \$JIRA_DESC" <"$1" >"$tmpfile"
+        cp "$tmpfile" "$1"
+        exit
+    fi
 
     printf "${c_action}%s ${c_value}%s ${c_action}%s${c_reset}\\n" "Applying Jira ticket" "$jira_ticket" "to commit message"
     JIRA="$jira_ticket" envsubst "\$JIRA" <"$1" >"$tmpfile"


### PR DESCRIPTION
This supports the use case where one might wish to create some feature branches
that are not associated with a Jira ticket. It allows for one to specify a
magic-string prefix, which defaults to `local`, to indicate that a branch
should not be subjected to the Jira-based hooks' checks and manipulations.

If you wish to use something other than `local`, set the
`git-hooks.non-ticketed-prefix` git config value.

[ENG-85](https://fivestars.atlassian.net/browse/ENG-85)