### PR TITLE
[ENG-92] Fix implicit sync-collection

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ A tool for managing and invoking custom git hook scripts.
 ### Global hooks:
  You can have global hooks on your machine. These will be run for any repository that has **git-hooks** installed (ie. has the multiplexer scripts in its `.git/hooks` dir. See **Installation** below). This is useful for applying consistent, project-agnostic rules across all of your projects (such as commit message format/structure). These hooks can be literal script files or reference hooks, but they will not be checked into the source control of the repositories that they will affect. They will appear and run alongside the repo's own hooks.  
 
- Global hooks will be enabled by default for all repos with **git-hooks** installed. If you wish to prevent the global git hooks from running for a repostiory, set the local git config value of `git-hooks.global-enabled` to `false` within the repository. This will allow you to continue to use the repo's source-controlled git hooks.  
+ Global hooks will be enabled by default for all repos with **git-hooks** installed. If you wish to prevent the global git hooks from running for a repository, set the local git config value of `git-hooks.global-enabled` to `false` within the repository. This will allow you to continue to use the repo's source-controlled git hooks.  
 
 ## Installation:
 

--- a/git-hooks
+++ b/git-hooks
@@ -126,7 +126,9 @@ function git_hooks__sync_collection {
             c_config_file="${c_path}/.git/config"
 
             if [[ -f "$c_config_file" ]]; then
-                git_hooks__update_if_needed "$force" "$c_path"
+                # We purposefully leave the quotes off of $c_global here to avoid problems
+                # with parameter assignment within the called function.
+                git_hooks__update_if_needed $force "$c_path"
             else
                 git clone "$c_location" "$c_path"
             fi
@@ -282,7 +284,7 @@ $(md_no_indent_or_hash "
 $(md_no_indent_or_hash "
     Global hooks will be enabled by default for all repos with $(md_inline_bold git-hooks)
     installed. If you wish to prevent the global git hooks from running for
-    a repostiory, set the local git config value of $(md_inline_quotes "git-hooks.global-enabled")
+    a repository, set the local git config value of $(md_inline_quotes "git-hooks.global-enabled")
     to $(md_inline_quotes false) within the repository. This will allow you to continue
     to use the repo's source-controlled git hooks.
 ")
@@ -1236,8 +1238,8 @@ function git_hooks_show_input {
 
 function git_hooks_config {
     : <<-HELP
-    Simply lists all hooks-related git config settings.
-HELP
+	    Simply lists all hooks-related git config settings.
+	HELP
 
     local -a files=( system global )
 
@@ -1483,8 +1485,10 @@ function git_hooks__run_referenced_hook {
     fi
 
     # Retrieve/update the collection referenced in this config
-    git_hooks__sync_collection "$c_global" "$c_name" ||:
-    git_hooks__ensure_collection "$c_global" "$c_name"
+    # We purposefully leave the quotes off of $c_global here to avoid problems
+    # with parameter assignment within the called functions.
+    git_hooks__sync_collection $c_global "$c_name" ||:
+    git_hooks__ensure_collection $c_global "$c_name"
 
     "${hooks_dir}/.collections/${c_name}/${c_subpath:+${c_subpath}/}$(git config -f "$hook_path" --get git-hooks.hook)" "$@"
 }

--- a/git-hooks-multiplexer
+++ b/git-hooks-multiplexer
@@ -139,8 +139,8 @@ count=0
 # Set a trap to clean up our temp file
 # shellcheck disable=2064
 trap "rm -f ${tmpfile}*" EXIT SIGHUP SIGINT SIGTERM
-# Collate our .githook scripts
 
+# Collate our .githook scripts
 while read -r _ hook_name hook hook_path; do
     if { ! $GITHOOKS_RUN; } && { git config --get-regexp "hooks\\.$HOOK\\.enabled" false &>/dev/null \
             || git config --get-regexp "hooks\\.${hook_name}-${hook}\\.enabled" false &>/dev/null; }; then


### PR DESCRIPTION
There was a subtle bug in this functionality that prevented the collection repos
from updating during the weekly check. We no longer wrap the `$force` parameter
in double-quotes when calling `git_hooks__update_if_needed`, as it will be
interpreted as a blank string for `$1` rather than as non-present when `$force`
is not set.

[ENG-92](https://fivestars.atlassian.net/browse/ENG-92)