### PR TITLE
[ENG-113] Only use global_githooks_dir if including a global hook

### DIFF
--- a/git-hooks
+++ b/git-hooks
@@ -1435,13 +1435,13 @@ function git_hooks_include {
         case "$1" in
             -g|--global)
                 global='-g'
-                hooks_dir="$global_githooks_dir"
                 if global_set="$(git config git-hooks.global-set)"; then
                     global_set_dir="${global_githooks_dir}/.global-sets/${global_set}"
                     mkdir -p "$global_set_dir"
                 else
                     global_set_dir="$global_githooks_dir"
                 fi
+                hooks_dir="$global_set_dir"
                 shift
                 ;;
         esac
@@ -1474,7 +1474,7 @@ function git_hooks_include {
             return 1
         fi
 
-        path="${global_set_dir}/${hook_name}/${as:-${hook}}"
+        path="${hooks_dir}/${hook_name}/${as:-${hook}}"
         mkdir -p "$(dirname "$path")"
         printf '#!/usr/bin/env git-hooks\n\n' > "$path"
         git config -f "$path" git-hooks.collection "$c_name"


### PR DESCRIPTION
The code was attempting to use the global_githooks_dir, even when the `-g` flag was not specified.
This resulted in an undefined variable error when one tried to include a hook in a local
repository's hooks (and not a global set).

This changes it so that the installation code uses `$githooks_dir` and ensures that it is set
correctly according to the `-g` flag's setting.

[ENG-113](https://fivestars.atlassian.net/browse/ENG-113)