### PR TITLE
[ENG-120] Disable git hooks when not invoked from a tty

### DIFF
--- a/git-hooks-multiplexer
+++ b/git-hooks-multiplexer
@@ -1,6 +1,10 @@
 #!/usr/bin/env bash
 set -eu -o pipefail
 
+# Ensure we are being invoked from a terminal (ie. tty)
+# We use stdout since git usually doesn't hook a tty up to stdin in the first place.
+[[ -t 1 ]] || exit
+
 # Determine which git hook is being run and make sure we're not accidentally
 # being called from another multiplexer script.
 # shellcheck disable=2155

--- a/git-hooks-multiplexer
+++ b/git-hooks-multiplexer
@@ -6,7 +6,7 @@ set -eu -o pipefail
 # first place and it seems to specifically hook one up to stdout.
 # Hopefully automated scripts attempt to capture stderr and as such
 # it wouldn't be a tty - meaning we shouldn't attempt to run the hooks.
-[[ -t 2 ]] || exit
+[[ -t 2 ]] || exit 0
 
 # Determine which git hook is being run and make sure we're not accidentally
 # being called from another multiplexer script.

--- a/git-hooks-multiplexer
+++ b/git-hooks-multiplexer
@@ -2,8 +2,11 @@
 set -eu -o pipefail
 
 # Ensure we are being invoked from a terminal (ie. tty)
-# We use stdout since git usually doesn't hook a tty up to stdin in the first place.
-[[ -t 1 ]] || exit
+# We use stderr since git usually doesn't hook a tty up to stdin in the
+# first place and it seems to specifically hook one up to stdout.
+# Hopefully automated scripts attempt to capture stderr and as such
+# it wouldn't be a tty - meaning we shouldn't attempt to run the hooks.
+[[ -t 2 ]] || exit
 
 # Determine which git hook is being run and make sure we're not accidentally
 # being called from another multiplexer script.


### PR DESCRIPTION
The hooks can cause issues when git operations are invoked by automated tools.

[ENG-120](https://fivestars.atlassian.net/browse/ENG-120)