### PR TITLE
[NA-350] Update old Jira links

### DIFF
--- a/.gitmessage.sample
+++ b/.gitmessage.sample
@@ -6,4 +6,4 @@ ${JIRA_DESC}
 # Summary: A paragraph or two explaining the reason for the change and a
 #          high level explanation of what the changes do.
 
-[$JIRA](https://fivestars.atlassian.net/browse/$JIRA)
+[$JIRA](https://jira.fivestars.com/browse/$JIRA)

--- a/included/lib/jira.sh
+++ b/included/lib/jira.sh
@@ -416,7 +416,7 @@ function jira_ensure_configuration_apitoken () {
     if ! api_token="$(git config jira.api-token 2>/dev/null)" || "$invalid"; then
         if [[ -z "${api_token:-}" ]]; then
             printf "    ${c_action}%s${c_reset}\\n" "Create a Jira API token"
-            open_uri "https://id.atlassian.com/manage/api-tokens"
+            open_uri "https://jira.fivestars.com/plugins/servlet/de.resolution.apitokenauth/admin"
         fi
 
         prompt_with_default_value "Enter your Jira api token" "${api_token:-}"


### PR DESCRIPTION
Updated Jira links in accordance to our Jira migration that was completed on 2June2021
[NA-350](https://jira.fivestars.com/browse/NA-350)