### PR TITLE
[PAY-2778] Update githooks repo to new Jira Server

### DIFF
--- a/.gitmessage.sample
+++ b/.gitmessage.sample
@@ -6,4 +6,4 @@ ${JIRA_DESC}
 # Summary: A paragraph or two explaining the reason for the change and a
 #          high level explanation of what the changes do.
 
-[$JIRA](https://jira.fivestars.com/browse/$JIRA)
+[$JIRA](https://sumupteam.atlassian.net/browse/$JIRA)

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## 1.6.0 - Update Jira urls
+*Date:* 2022-02-24
+
+*Tags:* `v1.6~~~~.0`
+
+### Features
+*No new features*
+
+### Changes
+- Update Jira urls to point at our new SumUp instance
+
+### Fixes
+*No fixes*
+
 ## 1.5.0 - Update Jira urls
 *Date:* 2021-06-14
 

--- a/included/lib/jira.sh
+++ b/included/lib/jira.sh
@@ -416,7 +416,7 @@ function jira_ensure_configuration_apitoken () {
     if ! api_token="$(git config jira.api-token 2>/dev/null)" || "$invalid"; then
         if [[ -z "${api_token:-}" ]]; then
             printf "    ${c_action}%s${c_reset}\\n" "Create a Jira API token"
-            open_uri "https://jira.fivestars.com/plugins/servlet/de.resolution.apitokenauth/admin"
+            open_uri "https://id.atlassian.com/manage-profile/security/api-tokens"
         fi
 
         prompt_with_default_value "Enter your Jira api token" "${api_token:-}"


### PR DESCRIPTION
Post Jira migration into sumup cloud, someone needs to update the git-hooks repo to reference sumup atlassian and tag a new release.

[PAY-2778](https://sumupteam.atlassian.net/browse/PAY-2778)